### PR TITLE
add a flag to specify --user in pgaudit_analyze script

### DIFF
--- a/analyze/bin/pgaudit_analyze
+++ b/analyze/bin/pgaudit_analyze
@@ -32,6 +32,7 @@ pgaudit_analyze [options]
    --port               port that PostgreSQL is running on (defaults to 5432)
    --socket-path        socket directory used by PostgreSQL (default to system default directory)
    --log-file           location of the log file for pgaudit_analyze (defaults to /var/log/pgaudit_analyze.log)
+   --user               specify postgres user instead of using pgaudit_analyze invoker
 
  General Options:
    --help               display usage and exit
@@ -119,12 +120,15 @@ my $bDaemon = false;
 my $iPort = 5432;
 my $strSocketPath;
 my $strLogOutFile = '/var/log/pgaudit_analyze.log';
+my $strDbUser = getpwuid($<);
+
 
 GetOptions ('help' => \$bHelp,
             'daemon' => \$bDaemon,
             'port=s' => \$iPort,
             'socket-path=s' => \$strSocketPath,
-            'log-file=s' => \$strLogOutFile)
+            'log-file=s' => \$strLogOutFile,
+            'user=s' => \$strDbUser)
     or pod2usage(2);
 
 # Display version and exit if requested
@@ -159,8 +163,6 @@ sub databaseGet
     }
 
     # Connect to the database
-    my $strDbUser = getpwuid($<);
-
     $oDbHash{$strDatabaseName}{hDb} = DBI->connect(
         "dbi:Pg:dbname=${strDatabaseName};port=${iPort};" .
         (defined($strSocketPath) ? "host=${strSocketPath}" : ''),


### PR DESCRIPTION
Hello,

I'd like to make a small contribution to the pgaudit_analyze script.
Currently, the script assumes that the user running the script is the postgres user.
There's an issue where if the script is invoked as root, the connection will fail.

There are two potential solutions that I can figure-- hardcode the user as "postgres", or add a new option flag to allow the user to be specified on the command line.  While the first solution would work, it does not allow extra flexibility for environments where the postgres user is different from the default case.  This submission allows for the new flag to be added, which should be a simple workaround.

Thank you!