### PR TITLE
Add set_user to docs, remove beta from doc versioning

### DIFF
--- a/doc/manifest.xml
+++ b/doc/manifest.xml
@@ -5,9 +5,10 @@
     <variable-list>
         <variable key="project">pgAudit</variable>
         <variable key="project-subtitle">Open Source PostgreSQL Audit Logging</variable>
-        <variable key="version">1.0beta</variable>
+        <variable key="version">1.0.0</variable>
 
         <variable key="project-analyze">{[project]} Analyze</variable>
+        <variable key="project-setuser">{[project]} Set User</variable>
 
         <variable key="postgres">PostgreSQL</variable>
         <variable key="dash">-</variable>

--- a/doc/xml/user-guide.xml
+++ b/doc/xml/user-guide.xml
@@ -999,4 +999,446 @@ select session.session_id,
             <p>* Reads and writes to the {[project]} schema by the user running {[project-analyze]} are never logged.</p>
         </section>
     </section>
+
+    <section id="set-user">
+        <title>PostgreSQL set_user Extension Module</title>
+
+        <section id="set-user-syntax">
+            <title>Syntax</title>
+
+            <code-block title="">
+set_user(text rolename) returns text
+reset_user() returns text
+            </code-block>
+        </section>
+        <section id="set-user-inputs">
+            <title>Inputs</title>
+
+            <p><b>rolename</b> is the role to be transitioned to.</p>
+        </section>
+        <section id="set-user-requirements">
+            <title>Requirements</title>
+
+            <p>* Add set_user to shared_preload_libraries in postgresql.conf.</p>
+            <p>* Optionally, the following custom parameters may be set to control their respective commands:</p>
+            <p>* set_user.block_alter_system = off (defaults to 'on')</p>
+            <p>* set_user.block_copy_program = off (defaults to 'on')</p>
+            <p>* set_user.block_log_statement = off (defaults to 'on')</p>
+        </section>
+        <section id="set-user-description">
+            <title>Description</title>
+
+            <p>This PostgreSQL extension allows privilege escalation with enhanced logging and
+            control. It provides an additional layer of logging and control when unprivileged
+            users must escalate themselves to superuser or object owner roles in order to
+            perform needed maintenance tasks. Specifically, when an allowed user executes
+            <b>set_user('rolename')</b>, several actions occur:</p>
+
+            <p>* The current effective user becomes <b>rolename</b>.</p>
+            <p>* The role transition is logged, with specific notation if <b>rolename</b> is a superuser.</p>
+            <p>* log_statement setting is set to 'all', meaning every SQL statement executed while in this state will also get logged.</p>
+            <p>* If set_user.block_alter_system is set to 'on', <b>ALTER SYSTEM</b> commands will be blocked.</p>
+            <p>* If set_user.block_copy_program is set to 'on', <b>COPY PROGRAM</b> commands will be blocked.</p>
+            <p>* If set_user.block_log_statement is set to 'on', <b>SET log_statement</b> and variations will be blocked.</p>
+
+            <p>When finished with required actions as <b>rolename</b>, the <b>reset_user()</b> function
+            is executed to restore the original user. At that point, these actions occur:</p>
+
+            <p>* Role transition is logged.</p>
+            <p>* log_statement setting is set to its original value.</p>
+            <p>* Blocked command behaviors return to normal.</p>
+
+            <p>The concept is to grant the EXECUTE privilege to the <b>set_user()</b>
+            function to otherwise unprivileged postgres users who can then
+            escalate themselves when needed to perform specific superuser actions.
+            The enhanced logging ensures an audit trail of what actions are taken
+            while privileges are escalated.</p>
+
+            <p>Once one or more unprivileged users are able to run <b>set_user()</b>,
+            the superuser account (normally <b>postgres</b>) can be altered to NOLOGIN,
+            preventing any direct database connection by a superuser which would
+            bypass the enhanced logging.</p>
+
+            <p>Naturally for this to work as expected, the PostgreSQL cluster must
+            be audited to ensure there are no other PostgreSQL roles existing which
+            are both superuser and can log in. Additionally there must be no
+            unprivileged PostgreSQL roles which have been granted access to one of
+            the existing superuser roles.</p>
+
+            <p>Note that for the blocking of <b>ALTER SYSTEM</b> and <b>COPY PROGRAM</b>
+            to work properly, you must include <b>set_user</b> in shared_preload_libraries
+            in postgresql.conf and restart PostgreSQL.</p>
+
+        </section>
+        <section id="set-user-caveats">
+            <title>Caveats</title>
+
+            <p>In its current state, this extension cannot prevent <b>rolename</b> from
+            performing a variety of nefarious or otherwise undesireable actions.
+            However, these actions will be logged providing an audit trail, which
+            could also be used to trigger alerts.</p>
+
+            <p>Although this extension compiles and works with all supported versions
+            of PostgreSQL starting with PostgreSQL 9.1, all features are not supported
+            until PostgreSQL 9.4 or higher. The ALTER SYSTEM command does not
+            exist prior to 9.4 and COPY PROGRAM does not exist prior to 9.3.</p>
+
+        </section>
+        <section id="set-user-installation">
+            <title>Installation</title>
+
+            <section id="set-user requirements">
+                <title>Requirements</title>
+
+                <p>* PostgreSQL 9.1 or higher.</p>
+            </section>
+
+            <section id="set-user-compile-and-install">
+                <title>Compile and Install</title>
+
+                <p>Clone PostgreSQL repository:</p>
+
+                <code-block title="">
+git clone https://github.com/postgres/postgres.git
+                </code-block>
+
+                <p>Checkout REL9_5_STABLE (for example) branch:</p>
+
+                <code-block title="">
+git checkout REL9_5_STABLE
+                </code-block>
+
+                <p>Make PostgreSQL:</p>
+
+                <code-block title="">
+./configure
+make install -s
+                </code-block>
+
+                <p>Change to the contrib directory:</p>
+
+                <code-block title="">
+cd contrib
+                </code-block>
+
+                <p>Clone <b>set_user</b> extension:</p>
+
+                <code-block title="">
+git clone https://github.com/pgaudit/set_user
+                </code-block>
+
+                <p>Change to <b>set_user</b> directory:</p>
+
+                <code-block title="">
+cd set_user
+                </code-block>
+
+                <p>Build <b>set_user</b>:</p>
+
+                <code-block title="">
+make
+                </code-block>
+
+                <p>Install <b>set_user</b>:</p>
+
+                <code-block title="">
+make install
+                </code-block>
+
+            </section>
+            <section id="set-user-using-pgxs">
+
+                <title>Using PGXS</title>
+
+                <p>If an instance of PostgreSQL is already installed, then PGXS can be utilized
+                to build and install <b>set_user</b>.  Ensure that PostgreSQL
+                binaries are available via the <b>PATH</b> environment variable then use the
+                following commands.</p>
+
+                <code-block title="">
+make USE_PGXS=1
+make USE_PGXS=1 install
+                </code-block>
+            </section>
+        </section>
+
+        <section id="set-user-configuration">
+            <title>Configure</title>
+
+            <p>The following bash commands should configure your system to utilize
+            set_user. Replace all paths as appropriate. It may be prudent to
+            visually inspect the files afterward to ensure the changes took place.</p>
+
+            <section id="set-user-configure-step1">
+
+                <title>Initialize PostgreSQL (if needed):</title>
+
+                <code-block title="">
+initdb -D /path/to/data/directory
+                </code-block>
+
+            </section>
+            <section id="set-user-configure-step2">
+
+                <title>Create Target Database (if needed):</title>
+
+                <code-block title="">
+createdb {database}
+                </code-block>
+
+            </section>
+            <section id="set-user-configure-step3">
+
+                <title>Install <b>set_user</b> functions:</title>
+
+                <p>Edit postgresql.conf and add <b>set_user</b> to the shared_preload_libraries
+                line, optionally also setting block_alter_system and/or block_copy_program.</p>
+
+                <p>First edit postgresql.conf in your favorite editor:</p>
+
+                <code-block title="">
+vi PGDATA/postgresql.conf
+                </code-block>
+
+                <p>Then add these lines to the end of the file:</p>
+                <code-block title="">
+# Add set_user to any existing list
+shared_preload_libraries = 'set_user'
+# The following lines are only required to turn off the
+# blocking of each respective command if desired
+set_user.block_alter_system = off       #defaults to 'on'
+set_user.block_copy_program = off       #defaults to 'on'
+set_user.block_log_statement = off      #defaults to 'on'
+                </code-block>
+
+                <p>Finally, restart PostgreSQL (method may vary):</p>
+
+                <code-block title="">
+service postgresql restart
+                </code-block>
+
+                <p>Install the extension into your database:</p>
+
+                <code-block title="">
+psql {database}
+CREATE EXTENSION set_user;
+                </code-block>
+
+            </section>
+        </section>
+
+        <section id="set-user-guc-parameters">
+            <title>GUC Parameters</title>
+
+            <p>* Block ALTER SYSTEM commands</p>
+            <p>* set_user.block_alter_system = on</p>
+            <p>* Block COPY PROGRAM commands</p>
+            <p>* set_user.block_copy_program = on</p>
+            <p>* Block SET log_statement commands</p>
+            <p>* set_user.block_log_statement = on</p>
+
+        </section>
+        <section id="set-user-examples">
+
+            <title>Examples</title>
+
+            <code-block title="">
+#################################
+# OS command line, terminal 1
+#################################
+psql -U postgres {dbname}
+
+---------------------------------
+-- psql command line, terminal 1
+---------------------------------
+SELECT rolname FROM pg_authid WHERE rolsuper and rolcanlogin;
+ rolname
+----------
+ postgres
+(1 row)
+
+CREATE EXTENSION set_user;
+CREATE USER dba_user;
+GRANT EXECUTE ON FUNCTION set_user(text) TO dba_user;
+
+#################################
+# OS command line, terminal 2
+#################################
+psql -U dba_user {dbname}
+
+---------------------------------
+-- psql command line, terminal 2
+---------------------------------
+SELECT set_user('postgres');
+SELECT CURRENT_USER, SESSION_USER;
+ current_user | session_user
+--------------+--------------
+ postgres     | dba_user
+(1 row)
+
+SELECT reset_user();
+SELECT CURRENT_USER, SESSION_USER;
+ current_user | session_user
+--------------+--------------
+ dba_user     | dba_user
+(1 row)
+
+\q
+
+---------------------------------
+-- psql command line, terminal 1
+---------------------------------
+ALTER USER postgres NOLOGIN;
+-- repeat terminal 2 test with dba_user before exiting
+\q
+
+#################################
+# OS command line, terminal 1
+#################################
+tail -n 6 {postgres log}
+LOG:  Role dba_user transitioning to Superuser Role postgres
+STATEMENT:  SELECT set_user('postgres');
+LOG:  statement: SELECT CURRENT_USER, SESSION_USER;
+LOG:  statement: SELECT reset_user();
+LOG:  Superuser Role postgres transitioning to Role dba_user
+STATEMENT:  SELECT reset_user();
+
+#################################
+# OS command line, terminal 2
+#################################
+psql -U dba_user {dbname}
+
+---------------------------------
+-- psql command line, terminal 2
+---------------------------------
+-- Verify there are no superusers that can login directly
+SELECT rolname FROM pg_authid WHERE rolsuper and rolcanlogin;
+ rolname
+---------
+(0 rows)
+
+-- Verify there are no unprivileged roles that can login directly
+-- that are granted a superuser role even if it is multiple layers
+-- removed
+DROP VIEW IF EXISTS roletree;
+CREATE OR REPLACE VIEW roletree AS
+WITH RECURSIVE
+roltree AS (
+  SELECT u.rolname AS rolname,
+         u.oid AS roloid,
+         u.rolcanlogin,
+         u.rolsuper,
+         '{}'::name[] AS rolparents,
+         NULL::oid AS parent_roloid,
+         NULL::name AS parent_rolname
+  FROM pg_catalog.pg_authid u
+  LEFT JOIN pg_catalog.pg_auth_members m on u.oid = m.member
+  LEFT JOIN pg_catalog.pg_authid g on m.roleid = g.oid
+  WHERE g.oid IS NULL
+  UNION ALL
+  SELECT u.rolname AS rolname,
+         u.oid AS roloid,
+         u.rolcanlogin,
+         u.rolsuper,
+         t.rolparents || g.rolname AS rolparents,
+         g.oid AS parent_roloid,
+         g.rolname AS parent_rolname
+  FROM pg_catalog.pg_authid u
+  JOIN pg_catalog.pg_auth_members m on u.oid = m.member
+  JOIN pg_catalog.pg_authid g on m.roleid = g.oid
+  JOIN roltree t on t.roloid = g.oid
+)
+SELECT
+  r.rolname,
+  r.roloid,
+  r.rolcanlogin,
+  r.rolsuper,
+  r.rolparents
+FROM roltree r
+ORDER BY 1;
+
+-- For example purposes, given this set of roles
+SELECT r.rolname, r.rolsuper, r.rolinherit,
+  r.rolcreaterole, r.rolcreatedb, r.rolcanlogin,
+  r.rolconnlimit, r.rolvaliduntil,
+  ARRAY(SELECT b.rolname
+        FROM pg_catalog.pg_auth_members m
+        JOIN pg_catalog.pg_roles b ON (m.roleid = b.oid)
+        WHERE m.member = r.oid) as memberof
+, r.rolreplication
+, r.rolbypassrls
+FROM pg_catalog.pg_roles r
+ORDER BY 1;
+                                    List of roles
+ Role name |                         Attributes                         | Member of
+-----------+------------------------------------------------------------+------------
+ bob       |                                                            | {}
+ dba_user  |                                                            | {su}
+ joe       |                                                            | {newbs}
+ newbs     | Cannot login                                               | {}
+ postgres  | Superuser, Create role, Create DB, Replication, Bypass RLS | {}
+ su        | No inheritance, Cannot login                               | {postgres}
+
+-- This query shows current status is not acceptable
+-- 1) postgres can login directly
+-- 2) dba_user can login and is able to escalate without using set_user()
+SELECT
+  ro.rolname,
+  ro.roloid,
+  ro.rolcanlogin,
+  ro.rolsuper,
+  ro.rolparents
+FROM roletree ro
+WHERE (ro.rolcanlogin AND ro.rolsuper)
+OR
+(
+    ro.rolcanlogin AND EXISTS
+    (
+      SELECT TRUE FROM roletree ri
+      WHERE ri.rolname = ANY (ro.rolparents)
+      AND ri.rolsuper
+    )
+);
+ rolname  | roloid | rolcanlogin | rolsuper |  rolparents
+----------+--------+-------------+----------+---------------
+ dba_user |  16387 | t           | f        | {postgres,su}
+ postgres |     10 | t           | t        | {}
+(2 rows)
+
+-- Fix it
+REVOKE postgres FROM su;
+ALTER USER postgres NOLOGIN;
+
+-- Rerun the query - shows current status is acceptable
+SELECT
+  ro.rolname,
+  ro.roloid,
+  ro.rolcanlogin,
+  ro.rolsuper,
+  ro.rolparents
+FROM roletree ro
+WHERE (ro.rolcanlogin AND ro.rolsuper)
+OR
+(
+    ro.rolcanlogin AND EXISTS
+    (
+      SELECT TRUE FROM roletree ri
+      WHERE ri.rolname = ANY (ro.rolparents)
+      AND ri.rolsuper
+    )
+);
+ rolname | roloid | rolcanlogin | rolsuper | rolparents
+---------+--------+-------------+----------+------------
+(0 rows)
+            </code-block>
+
+        </section>
+        <section id="set-user-licensing">
+
+            <title>Licensing</title>
+
+            <p>Please see the LICENSE file.</p>
+        </section>
+   </section>
+
 </doc>


### PR DESCRIPTION
Merge request to the feature-doc branch.

This merge request contains 2 things:
 - Removing the word beta from the document generator
 - I ported the README.md from the pgaudit/set_user documents over to the document generator, since that's part of the PGAudit Tools Suite.

I'm not sure if this is desired for inclusion at this time or not, but I figured I would submit a pull request anyway, so that the pgaudit suite of tools has a version of its documentation all in one place.  I probably need to do a cleanup pass on the docs, but this is a rough first attempt.