### PR TITLE
MISC_SET class

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ Specifies which classes of statements will be logged by session audit logging. P
 
 - **DDL**: All `DDL` that is not included in the `ROLE` class.
 
-- **MISC**: Miscellaneous commands, e.g. `DISCARD`, `FETCH`, `CHECKPOINT`, `VACUUM`.
+- **MISC**: Miscellaneous commands, e.g. `DISCARD`, `FETCH`, `CHECKPOINT`, `VACUUM`, `SET`.
+
+- **MISC_SET**: Miscellaneous `SET` commands, e.g. `SET ROLE`.
 
 Multiple classes can be provided using a comma-separated list and classes can be subtracted by prefacing the class with a `-` sign (see [Session Audit Logging](#session-audit-logging)).
 

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -1118,6 +1118,56 @@ NOTICE:  AUDIT: SESSION,68,1,READ,SELECT,TABLE,public.tmp,CREATE TABLE tmp2 AS (
 NOTICE:  AUDIT: SESSION,68,1,WRITE,INSERT,TABLE,public.tmp2,CREATE TABLE tmp2 AS (SELECT * FROM tmp);,<none>
 DROP TABLE tmp;
 DROP TABLE tmp2;
+--
+-- Test MISC
+SET pgaudit.log = 'MISC';
+NOTICE:  AUDIT: SESSION,69,1,MISC,SET,,,SET pgaudit.log = 'MISC';,<none>
+SET pgaudit.log_level = 'notice';
+NOTICE:  AUDIT: SESSION,70,1,MISC,SET,,,SET pgaudit.log_level = 'notice';,<none>
+SET pgaudit.log_client = ON;
+NOTICE:  AUDIT: SESSION,71,1,MISC,SET,,,SET pgaudit.log_client = ON;,<none>
+SET pgaudit.log_relation = ON;
+NOTICE:  AUDIT: SESSION,72,1,MISC,SET,,,SET pgaudit.log_relation = ON;,<none>
+SET pgaudit.log_parameter = ON;
+NOTICE:  AUDIT: SESSION,73,1,MISC,SET,,,SET pgaudit.log_parameter = ON;,<none>
+CREATE ROLE alice;
+SET ROLE alice;
+NOTICE:  AUDIT: SESSION,74,1,MISC,SET,,,SET ROLE alice;,<none>
+CREATE TABLE t (a int, b text);
+SET search_path TO test, public;
+NOTICE:  AUDIT: SESSION,75,1,MISC,SET,,,"SET search_path TO test, public;",<none>
+INSERT INTO t VALUES (1, 'misc');
+VACUUM t;
+NOTICE:  AUDIT: SESSION,76,1,MISC,VACUUM,,,VACUUM t;,<none>
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,77,1,MISC,RESET,,,RESET ROLE;,<none>
+--
+-- Test MISC_SET
+SET pgaudit.log = 'MISC_SET';
+NOTICE:  AUDIT: SESSION,78,1,MISC,SET,,,SET pgaudit.log = 'MISC_SET';,<none>
+SET ROLE alice;
+NOTICE:  AUDIT: SESSION,79,1,MISC,SET,,,SET ROLE alice;,<none>
+SET search_path TO public;
+NOTICE:  AUDIT: SESSION,80,1,MISC,SET,,,SET search_path TO public;,<none>
+INSERT INTO t VALUES (2, 'misc_set');
+VACUUM t;
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,81,1,MISC,RESET,,,RESET ROLE;,<none>
+--
+-- Test ALL, -MISC, MISC_SET
+SET pgaudit.log = 'ALL, -MISC, MISC_SET';
+NOTICE:  AUDIT: SESSION,82,1,MISC,SET,,,"SET pgaudit.log = 'ALL, -MISC, MISC_SET';",<none>
+SET search_path TO public;
+NOTICE:  AUDIT: SESSION,83,1,MISC,SET,,,SET search_path TO public;,<none>
+INSERT INTO t VALUES (3, 'all, -misc, misc_set');
+NOTICE:  AUDIT: SESSION,84,1,WRITE,INSERT,TABLE,public.t,"INSERT INTO t VALUES (3, 'all, -misc, misc_set');",<none>
+VACUUM t;
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,85,1,MISC,RESET,,,RESET ROLE;,<none>
+DROP TABLE public.t;
+NOTICE:  AUDIT: SESSION,86,1,DDL,DROP TABLE,,,DROP TABLE public.t;,<none>
+DROP ROLE alice;
+NOTICE:  AUDIT: SESSION,87,1,ROLE,DROP ROLE,,,DROP ROLE alice;,<none>
 -- Cleanup
 -- Set client_min_messages up to warning to avoid noise
 SET client_min_messages = 'warning';

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -613,8 +613,12 @@ log_audit_event(AuditEventStackItem *stackItem)
                     class = LOG_FUNCTION;
                     break;
 
+                /*
+                 * SET statements reported as MISC but filtered by MISC_SET
+                 * flags to maintain existing functionality.
+                 */
                 case T_VariableSetStmt:
-                    className = CLASS_MISC_SET;
+                    className = CLASS_MISC;
                     class = LOG_MISC_SET;
                     break;
 

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -61,6 +61,7 @@ PG_FUNCTION_INFO_V1(pgaudit_sql_drop);
 #define LOG_READ        (1 << 3)    /* SELECTs */
 #define LOG_ROLE        (1 << 4)    /* GRANT/REVOKE, CREATE/ALTER/DROP ROLE */
 #define LOG_WRITE       (1 << 5)    /* INSERT, UPDATE, DELETE, TRUNCATE */
+#define LOG_MISC_SET    (1 << 6)    /* SET ... */
 
 #define LOG_NONE        0               /* nothing */
 #define LOG_ALL         (0xFFFFFFFF)    /* All */
@@ -78,6 +79,7 @@ static int auditLogBitmap = LOG_NONE;
 #define CLASS_DDL       "DDL"
 #define CLASS_FUNCTION  "FUNCTION"
 #define CLASS_MISC      "MISC"
+#define CLASS_MISC_SET  "MISC_SET"
 #define CLASS_READ      "READ"
 #define CLASS_ROLE      "ROLE"
 #define CLASS_WRITE     "WRITE"
@@ -609,6 +611,11 @@ log_audit_event(AuditEventStackItem *stackItem)
                 case T_DoStmt:
                     className = CLASS_FUNCTION;
                     class = LOG_FUNCTION;
+                    break;
+
+                case T_VariableSetStmt:
+                    className = CLASS_MISC_SET;
+                    class = LOG_MISC_SET;
                     break;
 
                 default:
@@ -1697,7 +1704,9 @@ check_pgaudit_log(char **newVal, void **extra, GucSource source)
         else if (pg_strcasecmp(token, CLASS_FUNCTION) == 0)
             class = LOG_FUNCTION;
         else if (pg_strcasecmp(token, CLASS_MISC) == 0)
-            class = LOG_MISC;
+            class = LOG_MISC | LOG_MISC_SET;
+        else if (pg_strcasecmp(token, CLASS_MISC_SET) == 0)
+            class = LOG_MISC_SET;
         else if (pg_strcasecmp(token, CLASS_READ) == 0)
             class = LOG_READ;
         else if (pg_strcasecmp(token, CLASS_ROLE) == 0)

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -773,6 +773,51 @@ CREATE TABLE tmp2 AS (SELECT * FROM tmp);
 DROP TABLE tmp;
 DROP TABLE tmp2;
 
+--
+-- Test MISC
+SET pgaudit.log = 'MISC';
+SET pgaudit.log_level = 'notice';
+SET pgaudit.log_client = ON;
+SET pgaudit.log_relation = ON;
+SET pgaudit.log_parameter = ON;
+
+CREATE ROLE alice;
+
+SET ROLE alice;
+CREATE TABLE t (a int, b text);
+SET search_path TO test, public;
+
+INSERT INTO t VALUES (1, 'misc');
+
+VACUUM t;
+RESET ROLE;
+
+--
+-- Test MISC_SET
+SET pgaudit.log = 'MISC_SET';
+
+SET ROLE alice;
+SET search_path TO public;
+
+INSERT INTO t VALUES (2, 'misc_set');
+
+VACUUM t;
+RESET ROLE;
+
+--
+-- Test ALL, -MISC, MISC_SET
+SET pgaudit.log = 'ALL, -MISC, MISC_SET';
+
+SET search_path TO public;
+
+INSERT INTO t VALUES (3, 'all, -misc, misc_set');
+
+VACUUM t;
+
+RESET ROLE;
+DROP TABLE public.t;
+DROP ROLE alice;
+
 -- Cleanup
 -- Set client_min_messages up to warning to avoid noise
 SET client_min_messages = 'warning';


### PR DESCRIPTION
@dwsteele @sfrost @jconway This should allow us to split out `SET` logging from `MISC`, so you can opt into logging `SET` events, without the rest of the `MISC` class.

Potential issues:
- No flexible support for future filtering of `MISC` events, but that task is arguably left to a more specific mechanism.
- The `-` operator will exclude `MISC_SET` if `pgaudit.log = 'all -misc'`, but that seems like sane functionality to me. This can be tweaked if so desired.