### PR TITLE
Added `pgaudit.log_rows` option to get rows processed by a statement(#131)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ Specifies the master role to use for object audit logging. Multiple audit roles 
 
 There is no default.
 
+### pgaudit.log_rows
+
+Specifies that audit logging should include the rows retrieved or affected by a statement. When a rows field is present which will be included after the parameter field.
+
+The default is `off`.
+
 ## Session Audit Logging
 
 Session audit logging provides detailed logs of all statements executed by a user in the backend.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Specifies whether session audit logging should create a separate log entry for e
 
 The default is `off`.
 
+### pgaudit.log_rows
+
+Specifies that audit logging should include the rows retrieved or affected by a statement. When enabled the rows field will be included after the parameter field.
+
+The default is `off`.
+
 ### pgaudit.log_statement
 
 Specifies whether logging will include the statement text and parameters (if enabled). Depending on requirements, an audit log might not require this and it makes the logs less verbose.
@@ -177,12 +183,6 @@ The default is `off`.
 Specifies the master role to use for object audit logging. Multiple audit roles can be defined by granting them to the master role. This allows multiple groups to be in charge of different aspects of audit logging.
 
 There is no default.
-
-### pgaudit.log_rows
-
-Specifies that audit logging should include the rows retrieved or affected by a statement. When enabled the rows field will be included after the parameter field.
-
-The default is `off`.
 
 ## Session Audit Logging
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ There is no default.
 
 ### pgaudit.log_rows
 
-Specifies that audit logging should include the rows retrieved or affected by a statement. When a rows field is present which will be included after the parameter field.
+Specifies that audit logging should include the rows retrieved or affected by a statement. When enabled the rows field will be included after the parameter field.
 
 The default is `off`.
 

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -1568,7 +1568,7 @@ NOTICE:  AUDIT: SESSION,30,1,WRITE,DELETE,TABLE,public.test2,"DELETE
   FROM test2;",<none>,5
 DELETE
   FROM test3
- WHERE id > 0; 
+ WHERE id > 0;
 NOTICE:  AUDIT: SESSION,31,1,WRITE,DELETE,TABLE,public.test3,"DELETE
   FROM test3
  WHERE id > 0;",<none>,10

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -29,6 +29,7 @@ RESET pgaudit.log_level;
 --     STATEMENT - The statement being logged
 --     PARAMETER - If parameter logging is requested, they will follow the
 --                 statement
+--     ROWS - If rows logging is requested, they will follow the parameter
 SELECT current_user \gset
 --
 -- Set pgaudit parameters for the current (super)user.
@@ -1245,6 +1246,1207 @@ DROP INDEX h_idx;
 NOTICE:  AUDIT: SESSION,95,1,DDL,DROP INDEX,,,DROP INDEX h_idx;,<none>
 DROP TABLE h;
 NOTICE:  AUDIT: SESSION,96,1,DDL,DROP TABLE,,,DROP TABLE h;,<none>
+--
+-- Test rows retrived or affected by statements
+\connect - :current_user
+SET pgaudit.log = 'all';
+NOTICE:  AUDIT: SESSION,1,1,MISC,SET,,,SET pgaudit.log = 'all';,<not logged>
+SET pgaudit.log_client = on;
+NOTICE:  AUDIT: SESSION,2,1,MISC,SET,,,SET pgaudit.log_client = on;,<not logged>
+SET pgaudit.log_relation = on;
+NOTICE:  AUDIT: SESSION,3,1,MISC,SET,,,SET pgaudit.log_relation = on;,<not logged>
+SET pgaudit.log_statement_once = off;
+NOTICE:  AUDIT: SESSION,4,1,MISC,SET,,,SET pgaudit.log_statement_once = off;,<not logged>
+SET pgaudit.log_parameter = on;
+NOTICE:  AUDIT: SESSION,5,1,MISC,SET,,,SET pgaudit.log_parameter = on;,<none>
+SET pgaudit.log_rows = on;
+NOTICE:  AUDIT: SESSION,6,1,MISC,SET,,,SET pgaudit.log_rows = on;,<none>,0
+--
+-- Test DDL
+CREATE TABLE test2
+(
+	id int,
+	name text
+);
+NOTICE:  AUDIT: SESSION,7,1,DDL,CREATE TABLE,,,"CREATE TABLE test2
+(
+	id int,
+	name text
+);",<none>,0
+CREATE TABLE test3
+(
+	id int,
+	name text
+);
+NOTICE:  AUDIT: SESSION,8,1,DDL,CREATE TABLE,,,"CREATE TABLE test3
+(
+	id int,
+	name text
+);",<none>,0
+CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id;
+
+	RETURN new;
+END $$ LANGUAGE plpgsql security definer;
+NOTICE:  AUDIT: SESSION,9,1,DDL,CREATE FUNCTION,,,"CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id;
+
+	RETURN new;
+END $$ LANGUAGE plpgsql security definer;",<none>,0
+CREATE TRIGGER test2_insert_trg
+	AFTER INSERT ON test2
+	FOR EACH ROW EXECUTE PROCEDURE test2_insert();
+NOTICE:  AUDIT: SESSION,10,1,DDL,CREATE TRIGGER,,,"CREATE TRIGGER test2_insert_trg
+	AFTER INSERT ON test2
+	FOR EACH ROW EXECUTE PROCEDURE test2_insert();",<none>,0
+CREATE FUNCTION test2_change(change_id int) RETURNS void AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 1
+	 WHERE id = change_id;
+END $$ LANGUAGE plpgsql security definer;
+NOTICE:  AUDIT: SESSION,11,1,DDL,CREATE FUNCTION,,,"CREATE FUNCTION test2_change(change_id int) RETURNS void AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 1
+	 WHERE id = change_id;
+END $$ LANGUAGE plpgsql security definer;",<none>,0
+CREATE VIEW vw_test3 AS
+SELECT *
+  FROM test3;
+NOTICE:  AUDIT: SESSION,12,1,DDL,CREATE VIEW,,,"CREATE VIEW vw_test3 AS
+SELECT *
+  FROM test3;",<none>,0
+--
+-- Test DML
+INSERT INTO test2 (id, name)
+		  VALUES (1, 'a');
+NOTICE:  AUDIT: SESSION,13,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id",",,,,,,,,,,,,,1",1
+NOTICE:  AUDIT: SESSION,13,2,WRITE,INSERT,TABLE,public.test2,"INSERT INTO test2 (id, name)
+		  VALUES (1, 'a');",<none>,1
+INSERT INTO test2 (id, name)
+		  VALUES (2, 'b');
+NOTICE:  AUDIT: SESSION,14,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id",",,,,,,,,,,,,,2",1
+NOTICE:  AUDIT: SESSION,14,2,WRITE,INSERT,TABLE,public.test2,"INSERT INTO test2 (id, name)
+		  VALUES (2, 'b');",<none>,1
+INSERT INTO test2 (id, name)
+		  VALUES (3, 'c');
+NOTICE:  AUDIT: SESSION,15,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id",",,,,,,,,,,,,,3",1
+NOTICE:  AUDIT: SESSION,15,2,WRITE,INSERT,TABLE,public.test2,"INSERT INTO test2 (id, name)
+		  VALUES (3, 'c');",<none>,1
+INSERT INTO test3 (id, name)
+		  VALUES (1, 'a');
+NOTICE:  AUDIT: SESSION,16,1,WRITE,INSERT,TABLE,public.test3,"INSERT INTO test3 (id, name)
+		  VALUES (1, 'a');",<none>,1
+INSERT INTO test3 (id, name)
+		  VALUES (2, 'b');
+NOTICE:  AUDIT: SESSION,17,1,WRITE,INSERT,TABLE,public.test3,"INSERT INTO test3 (id, name)
+		  VALUES (2, 'b');",<none>,1
+INSERT INTO test3 (id, name)
+		  VALUES (3, 'c');
+NOTICE:  AUDIT: SESSION,18,1,WRITE,INSERT,TABLE,public.test3,"INSERT INTO test3 (id, name)
+		  VALUES (3, 'c');",<none>,1
+SELECT *
+  FROM test3, test2;
+NOTICE:  AUDIT: SESSION,19,1,READ,SELECT,TABLE,public.test3,"SELECT *
+  FROM test3, test2;",<none>,9
+NOTICE:  AUDIT: SESSION,19,1,READ,SELECT,TABLE,public.test2,"SELECT *
+  FROM test3, test2;",<none>,9
+ id | name | id | name 
+----+------+----+------
+  1 | a    | 91 | a
+  1 | a    | 92 | b
+  1 | a    | 93 | c
+  2 | b    | 91 | a
+  2 | b    | 92 | b
+  2 | b    | 93 | c
+  3 | c    | 91 | a
+  3 | c    | 92 | b
+  3 | c    | 93 | c
+(9 rows)
+
+SELECT *
+  FROM vw_test3, test2;
+NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,TABLE,public.test2,"SELECT *
+  FROM vw_test3, test2;",<none>,9
+NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,VIEW,public.vw_test3,"SELECT *
+  FROM vw_test3, test2;",<none>,9
+NOTICE:  AUDIT: SESSION,20,1,MISC,???,VIEW,public.vw_test3,"SELECT *
+  FROM vw_test3, test2;",<none>,9
+NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,TABLE,public.test3,"SELECT *
+  FROM vw_test3, test2;",<none>,9
+ id | name | id | name 
+----+------+----+------
+  1 | a    | 91 | a
+  1 | a    | 92 | b
+  1 | a    | 93 | c
+  2 | b    | 91 | a
+  2 | b    | 92 | b
+  2 | b    | 93 | c
+  3 | c    | 91 | a
+  3 | c    | 92 | b
+  3 | c    | 93 | c
+(9 rows)
+
+SELECT *
+  FROM test2
+ ORDER BY ID;
+NOTICE:  AUDIT: SESSION,21,1,READ,SELECT,TABLE,public.test2,"SELECT *
+  FROM test2
+ ORDER BY ID;",<none>,3
+ id | name 
+----+------
+ 91 | a
+ 92 | b
+ 93 | c
+(3 rows)
+
+UPDATE test2
+   SET name = 'd';
+NOTICE:  AUDIT: SESSION,22,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+   SET name = 'd';",<none>,3
+UPDATE test3
+   SET name = 'd'
+ WHERE id > 0;
+NOTICE:  AUDIT: SESSION,23,1,WRITE,UPDATE,TABLE,public.test3,"UPDATE test3
+   SET name = 'd'
+ WHERE id > 0;",<none>,3
+SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	  LIMIT 3
+) SUBQUERY;
+NOTICE:  AUDIT: SESSION,24,1,READ,SELECT,TABLE,pg_catalog.pg_class,"SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	  LIMIT 3
+) SUBQUERY;",<none>,3
+ ?column? 
+----------
+        1
+        1
+        1
+(3 rows)
+
+WITH CTE AS
+(
+	SELECT id
+	  FROM test2
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;
+NOTICE:  AUDIT: SESSION,25,1,WRITE,INSERT,TABLE,public.test3,"WITH CTE AS
+(
+	SELECT id
+	  FROM test2
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;",<none>,3
+NOTICE:  AUDIT: SESSION,25,1,READ,SELECT,TABLE,public.test2,"WITH CTE AS
+(
+	SELECT id
+	  FROM test2
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;",<none>,3
+WITH CTE AS
+(
+	INSERT INTO test3 VALUES (1)
+				   RETURNING id
+)
+INSERT INTO test2
+SELECT id
+  FROM cte;
+NOTICE:  AUDIT: SESSION,26,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id",",,,,,,,,,,,,,1",1
+NOTICE:  AUDIT: SESSION,26,2,WRITE,INSERT,TABLE,public.test2,"WITH CTE AS
+(
+	INSERT INTO test3 VALUES (1)
+				   RETURNING id
+)
+INSERT INTO test2
+SELECT id
+  FROM cte;",<none>,1
+NOTICE:  AUDIT: SESSION,26,2,WRITE,INSERT,TABLE,public.test3,"WITH CTE AS
+(
+	INSERT INTO test3 VALUES (1)
+				   RETURNING id
+)
+INSERT INTO test2
+SELECT id
+  FROM cte;",<none>,1
+DO $$ BEGIN PERFORM test2_change(91); END $$;
+NOTICE:  AUDIT: SESSION,27,1,FUNCTION,DO,,,DO $$ BEGIN PERFORM test2_change(91); END $$;,<none>,0
+NOTICE:  AUDIT: SESSION,27,2,FUNCTION,EXECUTE,FUNCTION,public.test2_change,SELECT test2_change(91),<none>,0
+NOTICE:  AUDIT: SESSION,27,3,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 1
+	 WHERE id = change_id","91,",2
+NOTICE:  AUDIT: SESSION,27,4,READ,SELECT,,,SELECT test2_change(91),<none>,1
+WITH CTE AS
+(
+	UPDATE test2
+	   SET id = 45
+	 WHERE id = 92
+	RETURNING id
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;
+NOTICE:  AUDIT: SESSION,28,1,WRITE,INSERT,TABLE,public.test3,"WITH CTE AS
+(
+	UPDATE test2
+	   SET id = 45
+	 WHERE id = 92
+	RETURNING id
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;",<none>,3
+NOTICE:  AUDIT: SESSION,28,1,WRITE,UPDATE,TABLE,public.test2,"WITH CTE AS
+(
+	UPDATE test2
+	   SET id = 45
+	 WHERE id = 92
+	RETURNING id
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;",<none>,3
+WITH CTE AS
+(
+	INSERT INTO test2 VALUES (37)
+				   RETURNING id
+)
+UPDATE test3
+   SET id = cte.id
+  FROM cte
+ WHERE test3.id <> cte.id;
+NOTICE:  AUDIT: SESSION,29,1,WRITE,UPDATE,TABLE,public.test2,"UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id",",,,,,,,,,,,,,37",1
+NOTICE:  AUDIT: SESSION,29,2,WRITE,UPDATE,TABLE,public.test3,"WITH CTE AS
+(
+	INSERT INTO test2 VALUES (37)
+				   RETURNING id
+)
+UPDATE test3
+   SET id = cte.id
+  FROM cte
+ WHERE test3.id <> cte.id;",<none>,10
+NOTICE:  AUDIT: SESSION,29,2,WRITE,INSERT,TABLE,public.test2,"WITH CTE AS
+(
+	INSERT INTO test2 VALUES (37)
+				   RETURNING id
+)
+UPDATE test3
+   SET id = cte.id
+  FROM cte
+ WHERE test3.id <> cte.id;",<none>,10
+DELETE
+  FROM test2;
+NOTICE:  AUDIT: SESSION,30,1,WRITE,DELETE,TABLE,public.test2,"DELETE
+  FROM test2;",<none>,5
+DELETE
+  FROM test3
+ WHERE id > 0; 
+NOTICE:  AUDIT: SESSION,31,1,WRITE,DELETE,TABLE,public.test3,"DELETE
+  FROM test3
+ WHERE id > 0;",<none>,10
+--
+-- Drop test tables
+DROP TABLE test2;
+NOTICE:  AUDIT: SESSION,32,1,DDL,DROP TABLE,,,DROP TABLE test2;,<none>,0
+DROP VIEW vw_test3;
+NOTICE:  AUDIT: SESSION,33,1,DDL,DROP VIEW,,,DROP VIEW vw_test3;,<none>,0
+DROP TABLE test3;
+NOTICE:  AUDIT: SESSION,34,1,DDL,DROP TABLE,,,DROP TABLE test3;,<none>,0
+DROP FUNCTION test2_insert();
+NOTICE:  AUDIT: SESSION,35,1,DDL,DROP FUNCTION,,,DROP FUNCTION test2_insert();,<none>,0
+DROP FUNCTION test2_change(int);
+NOTICE:  AUDIT: SESSION,36,1,DDL,DROP FUNCTION,,,DROP FUNCTION test2_change(int);,<none>,0
+--
+-- Only object logging will be done
+SET pgaudit.log = 'none';
+SET pgaudit.role = 'auditor';
+--
+-- Select is session logged
+SELECT *
+  FROM account;
+NOTICE:  AUDIT: OBJECT,37,1,READ,SELECT,TABLE,public.account,"SELECT *
+  FROM account;",<none>,1
+ id | name  | password | description 
+----+-------+----------+-------------
+  1 | user1 | HASH2    | yada, yada
+(1 row)
+
+--
+-- Insert is not logged
+INSERT INTO account (id, name, password, description)
+			 VALUES (1, 'user2', 'HASH3', 'blah, blah2');
+INSERT INTO account (id, name, password, description)
+			 VALUES (1, 'user3', 'HASH4', 'blah, blah3');
+--
+-- Not object logged
+SELECT id,
+	   name
+  FROM account;
+ id | name  
+----+-------
+  1 | user1
+  1 | user2
+  1 | user3
+(3 rows)
+
+--
+-- Object logged because of:
+-- select (password) on account
+SELECT password
+  FROM account;
+NOTICE:  AUDIT: OBJECT,38,1,READ,SELECT,TABLE,public.account,"SELECT password
+  FROM account;",<none>,3
+ password 
+----------
+ HASH2
+ HASH3
+ HASH4
+(3 rows)
+
+--
+-- Not object logged
+UPDATE account
+   SET description = 'yada, yada1';
+--
+-- Object logged because of:
+-- update (password) on account
+UPDATE account
+   SET password = 'HASH4';
+NOTICE:  AUDIT: OBJECT,39,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET password = 'HASH4';",<none>,3
+--
+-- Session relation logging will be done
+SET pgaudit.log_relation = on;
+SET pgaudit.log = 'read, write';
+--
+-- Object logged because of:
+-- select (password) on account
+-- select on account_role_map
+-- Session logged on all tables because log = read and log_relation = on
+SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;
+NOTICE:  AUDIT: OBJECT,40,1,READ,SELECT,TABLE,public.account,"SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;",<none>,0
+NOTICE:  AUDIT: SESSION,40,1,READ,SELECT,TABLE,public.account,"SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;",<none>,0
+NOTICE:  AUDIT: OBJECT,40,1,READ,SELECT,TABLE,public.account_role_map,"SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;",<none>,0
+NOTICE:  AUDIT: SESSION,40,1,READ,SELECT,TABLE,public.account_role_map,"SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;",<none>,0
+ password | role_id 
+----------+---------
+(0 rows)
+
+--
+-- Object logged because of:
+-- select (password) on account
+-- Session logged on all tables because log = read and log_relation = on
+SELECT password
+  FROM account;
+NOTICE:  AUDIT: OBJECT,41,1,READ,SELECT,TABLE,public.account,"SELECT password
+  FROM account;",<none>,3
+NOTICE:  AUDIT: SESSION,41,1,READ,SELECT,TABLE,public.account,"SELECT password
+  FROM account;",<none>,3
+ password 
+----------
+ HASH4
+ HASH4
+ HASH4
+(3 rows)
+
+--
+-- Not object logged
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET description = 'yada, yada2';
+NOTICE:  AUDIT: SESSION,42,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET description = 'yada, yada2';",<none>,3
+--
+-- Object logged because of:
+-- select (password) on account (in the where clause)
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET description = 'yada, yada3'
+ where password = 'HASH4';
+NOTICE:  AUDIT: OBJECT,43,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET description = 'yada, yada3'
+ where password = 'HASH4';",<none>,3
+NOTICE:  AUDIT: SESSION,43,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET description = 'yada, yada3'
+ where password = 'HASH4';",<none>,3
+--
+-- Object logged because of:
+-- update (password) on account
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET password = 'HASH4';
+NOTICE:  AUDIT: OBJECT,44,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET password = 'HASH4';",<none>,3
+NOTICE:  AUDIT: SESSION,44,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+   SET password = 'HASH4';",<none>,3
+--
+-- Exhaustive tests
+SET pgaudit.log = 'all';
+NOTICE:  AUDIT: SESSION,45,1,MISC,SET,,,SET pgaudit.log = 'all';,<none>,0
+SET pgaudit.log_client = on;
+NOTICE:  AUDIT: SESSION,46,1,MISC,SET,,,SET pgaudit.log_client = on;,<none>,0
+SET pgaudit.log_relation = on;
+NOTICE:  AUDIT: SESSION,47,1,MISC,SET,,,SET pgaudit.log_relation = on;,<none>,0
+SET pgaudit.log_parameter = on;
+NOTICE:  AUDIT: SESSION,48,1,MISC,SET,,,SET pgaudit.log_parameter = on;,<none>,0
+SET pgaudit.log_rows = on;
+NOTICE:  AUDIT: SESSION,49,1,MISC,SET,,,SET pgaudit.log_rows = on;,<none>,0
+--
+-- Simple DO block
+DO $$
+BEGIN
+	raise notice 'test';
+END $$;
+NOTICE:  AUDIT: SESSION,50,1,FUNCTION,DO,,,"DO $$
+BEGIN
+	raise notice 'test';
+END $$;",<none>,0
+NOTICE:  test
+--
+-- Copy account to stdout
+COPY account TO stdout;
+1	user1	HASH4	yada, yada3
+1	user2	HASH4	yada, yada3
+1	user3	HASH4	yada, yada3
+NOTICE:  AUDIT: SESSION,51,1,READ,COPY,,,COPY account TO stdout;,<none>,0
+--
+-- Drop a table from a query
+DROP TABLE test.account_copy;
+NOTICE:  AUDIT: SESSION,52,1,DDL,DROP TABLE,,,DROP TABLE test.account_copy;,<none>,0
+--
+-- Create a table from a query
+CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account;
+NOTICE:  AUDIT: OBJECT,53,1,READ,SELECT,TABLE,public.account,"CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account;",<none>,3
+NOTICE:  AUDIT: SESSION,53,1,READ,SELECT,TABLE,public.account,"CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account;",<none>,3
+NOTICE:  AUDIT: SESSION,53,2,DDL,CREATE TABLE AS,,,"CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account;",<none>,0
+--
+-- Copy from stdin to account copy
+COPY test.account_copy from stdin;
+NOTICE:  AUDIT: SESSION,54,1,WRITE,COPY,,,COPY test.account_copy from stdin;,<none>,0
+--
+-- Test prepared statement
+PREPARE pgclassstmt1 (oid) AS
+SELECT 1
+  FROM account
+ WHERE id = $1;
+NOTICE:  AUDIT: SESSION,55,1,READ,PREPARE,,,"PREPARE pgclassstmt1 (oid) AS
+SELECT 1
+  FROM account
+ WHERE id = $1;",<none>,0
+PREPARE pgclassstmt2 (oid) AS
+SELECT 2
+  FROM account
+ WHERE id = $1;
+NOTICE:  AUDIT: SESSION,56,1,READ,PREPARE,,,"PREPARE pgclassstmt2 (oid) AS
+SELECT 2
+  FROM account
+ WHERE id = $1;",<none>,0
+EXECUTE pgclassstmt2 (1);
+NOTICE:  AUDIT: SESSION,57,1,READ,SELECT,TABLE,public.account,"PREPARE pgclassstmt2 (oid) AS
+SELECT 2
+  FROM account
+ WHERE id = $1;",1,3
+NOTICE:  AUDIT: SESSION,57,2,MISC,EXECUTE,,,EXECUTE pgclassstmt2 (1);,<none>,0
+ ?column? 
+----------
+        2
+        2
+        2
+(3 rows)
+
+EXECUTE pgclassstmt1 (1);
+NOTICE:  AUDIT: SESSION,58,1,READ,SELECT,TABLE,public.account,"PREPARE pgclassstmt1 (oid) AS
+SELECT 1
+  FROM account
+ WHERE id = $1;",1,3
+NOTICE:  AUDIT: SESSION,58,2,MISC,EXECUTE,,,EXECUTE pgclassstmt1 (1);,<none>,0
+ ?column? 
+----------
+        1
+        1
+        1
+(3 rows)
+
+DEALLOCATE pgclassstmt2;
+NOTICE:  AUDIT: SESSION,59,1,MISC,DEALLOCATE,,,DEALLOCATE pgclassstmt2;,<none>,0
+DEALLOCATE pgclassstmt1;
+NOTICE:  AUDIT: SESSION,60,1,MISC,DEALLOCATE,,,DEALLOCATE pgclassstmt1;,<none>,0
+--
+-- Test cursor
+BEGIN;
+NOTICE:  AUDIT: SESSION,61,1,MISC,BEGIN,,,BEGIN;,<none>,0
+DECLARE ctest1 SCROLL CURSOR FOR
+SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;
+NOTICE:  AUDIT: SESSION,62,1,READ,DECLARE CURSOR,,,"DECLARE ctest1 SCROLL CURSOR FOR
+SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;",<none>,0
+DECLARE ctest2 SCROLL CURSOR FOR
+SELECT 2
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;
+NOTICE:  AUDIT: SESSION,63,1,READ,DECLARE CURSOR,,,"DECLARE ctest2 SCROLL CURSOR FOR
+SELECT 2
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;",<none>,0
+FETCH NEXT FROM ctest1;
+NOTICE:  AUDIT: SESSION,64,1,MISC,FETCH,,,FETCH NEXT FROM ctest1;,<none>,0
+ ?column? 
+----------
+        1
+(1 row)
+
+FETCH NEXT FROM ctest2;
+NOTICE:  AUDIT: SESSION,65,1,MISC,FETCH,,,FETCH NEXT FROM ctest2;,<none>,0
+ ?column? 
+----------
+        2
+(1 row)
+
+FETCH NEXT FROM ctest1;
+NOTICE:  AUDIT: SESSION,66,1,MISC,FETCH,,,FETCH NEXT FROM ctest1;,<none>,0
+ ?column? 
+----------
+        1
+(1 row)
+
+FETCH NEXT FROM ctest2;
+NOTICE:  AUDIT: SESSION,67,1,MISC,FETCH,,,FETCH NEXT FROM ctest2;,<none>,0
+ ?column? 
+----------
+        2
+(1 row)
+
+FETCH NEXT FROM ctest1;
+NOTICE:  AUDIT: SESSION,68,1,MISC,FETCH,,,FETCH NEXT FROM ctest1;,<none>,0
+ ?column? 
+----------
+        1
+(1 row)
+
+FETCH NEXT FROM ctest2;
+NOTICE:  AUDIT: SESSION,69,1,MISC,FETCH,,,FETCH NEXT FROM ctest2;,<none>,0
+ ?column? 
+----------
+        2
+(1 row)
+
+CLOSE ctest2;
+NOTICE:  AUDIT: SESSION,70,1,MISC,CLOSE CURSOR,,,CLOSE ctest2;,<none>,0
+CLOSE ctest1;
+NOTICE:  AUDIT: SESSION,71,1,MISC,CLOSE CURSOR,,,CLOSE ctest1;,<none>,0
+COMMIT;
+NOTICE:  AUDIT: SESSION,72,1,MISC,COMMIT,,,COMMIT;,<none>,0
+--
+-- Turn off log_catalog and pg_class will not be logged
+SET pgaudit.log_catalog = off;
+NOTICE:  AUDIT: SESSION,73,1,MISC,SET,,,SET pgaudit.log_catalog = off;,<none>,0
+SELECT count(*)
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 1
+ ) subquery;
+ count 
+-------
+     1
+(1 row)
+
+--
+-- Test prepared insert
+DROP TABLE test.test_insert;
+NOTICE:  AUDIT: SESSION,74,1,DDL,DROP TABLE,,,DROP TABLE test.test_insert;,<none>,0
+--
+-- Test prepared insert
+CREATE TABLE test.test_insert
+(
+	id INT
+);
+NOTICE:  AUDIT: SESSION,75,1,DDL,CREATE TABLE,,,"CREATE TABLE test.test_insert
+(
+	id INT
+);",<none>,0
+PREPARE pgclassstmt (oid) AS
+INSERT INTO test.test_insert (id)
+					  VALUES ($1);
+NOTICE:  AUDIT: SESSION,76,1,WRITE,PREPARE,,,"PREPARE pgclassstmt (oid) AS
+INSERT INTO test.test_insert (id)
+					  VALUES ($1);",<none>,0
+EXECUTE pgclassstmt (1);
+NOTICE:  AUDIT: SESSION,77,1,WRITE,INSERT,TABLE,test.test_insert,"PREPARE pgclassstmt (oid) AS
+INSERT INTO test.test_insert (id)
+					  VALUES ($1);",1,1
+NOTICE:  AUDIT: SESSION,77,2,MISC,EXECUTE,,,EXECUTE pgclassstmt (1);,<none>,0
+--
+-- Check that primary key creation is logged
+CREATE TABLE public.test
+(
+	id INT,
+	name TEXT,
+	description TEXT,
+	CONSTRAINT test_pkey PRIMARY KEY (id)
+);
+NOTICE:  AUDIT: SESSION,78,1,DDL,CREATE TABLE,,,"CREATE TABLE public.test
+(
+	id INT,
+	name TEXT,
+	description TEXT,
+	CONSTRAINT test_pkey PRIMARY KEY (id)
+);",<none>,0
+--
+-- Check that analyze is logged
+ANALYZE test;
+NOTICE:  AUDIT: SESSION,79,1,MISC,ANALYZE,,,ANALYZE test;,<none>,0
+--
+-- Grants to public should not cause object logging (session logging will
+-- still happen)
+GRANT SELECT
+  ON TABLE public.test
+  TO PUBLIC;
+NOTICE:  AUDIT: SESSION,80,1,ROLE,GRANT,,,"GRANT SELECT
+  ON TABLE public.test
+  TO PUBLIC;",<none>,0
+SELECT *
+  FROM test;
+NOTICE:  AUDIT: SESSION,81,1,READ,SELECT,TABLE,public.test,"SELECT *
+  FROM test;",<none>,0
+ id | name | description 
+----+------+-------------
+(0 rows)
+
+-- Check that statements without columns log
+SELECT
+  FROM test;
+NOTICE:  AUDIT: SESSION,82,1,READ,SELECT,TABLE,public.test,"SELECT
+  FROM test;",<none>,0
+--
+(0 rows)
+
+SELECT 1,
+	   substring('Thomas' from 2 for 3);
+NOTICE:  AUDIT: SESSION,83,1,READ,SELECT,,,"SELECT 1,
+	   substring('Thomas' from 2 for 3);",<none>,1
+ ?column? | substring 
+----------+-----------
+        1 | hom
+(1 row)
+
+DO $$
+DECLARE
+	test INT;
+BEGIN
+	SELECT 1
+	  INTO test;
+END $$;
+NOTICE:  AUDIT: SESSION,84,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	test INT;
+BEGIN
+	SELECT 1
+	  INTO test;
+END $$;",<none>,0
+NOTICE:  AUDIT: SESSION,84,2,READ,SELECT,,,SELECT 1,<none>,1
+explain select 1;
+NOTICE:  AUDIT: SESSION,85,1,READ,SELECT,,,explain select 1;,<none>,0
+NOTICE:  AUDIT: SESSION,85,2,MISC,EXPLAIN,,,explain select 1;,<none>,0
+                QUERY PLAN                
+------------------------------------------
+ Result  (cost=0.00..0.01 rows=1 width=4)
+(1 row)
+
+--
+-- Test that looks inside of do blocks log
+INSERT INTO TEST (id)
+		  VALUES (1);
+NOTICE:  AUDIT: SESSION,86,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+		  VALUES (1);",<none>,1
+INSERT INTO TEST (id)
+		  VALUES (2);
+NOTICE:  AUDIT: SESSION,87,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+		  VALUES (2);",<none>,1
+INSERT INTO TEST (id)
+		  VALUES (3);
+NOTICE:  AUDIT: SESSION,88,1,WRITE,INSERT,TABLE,public.test,"INSERT INTO TEST (id)
+		  VALUES (3);",<none>,1
+DO $$
+DECLARE
+	result RECORD;
+BEGIN
+	FOR result IN
+		SELECT id
+		  FROM test
+	LOOP
+		INSERT INTO test (id)
+			 VALUES (result.id + 100);
+	END LOOP;
+END $$;
+NOTICE:  AUDIT: SESSION,89,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	result RECORD;
+BEGIN
+	FOR result IN
+		SELECT id
+		  FROM test
+	LOOP
+		INSERT INTO test (id)
+			 VALUES (result.id + 100);
+	END LOOP;
+END $$;",<none>,0
+NOTICE:  AUDIT: SESSION,89,2,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
+			 VALUES (result.id + 100)",",,1",1
+NOTICE:  AUDIT: SESSION,89,3,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
+			 VALUES (result.id + 100)",",,2",1
+NOTICE:  AUDIT: SESSION,89,4,WRITE,INSERT,TABLE,public.test,"INSERT INTO test (id)
+			 VALUES (result.id + 100)",",,3",1
+NOTICE:  AUDIT: SESSION,89,5,READ,SELECT,TABLE,public.test,"SELECT id
+		  FROM test",<none>,3
+--
+-- Test obfuscated dynamic sql for clean logging
+DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' ("weird name" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;
+NOTICE:  AUDIT: SESSION,90,1,FUNCTION,DO,,,"DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' (""weird name"" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;",<none>,0
+NOTICE:  AUDIT: SESSION,90,2,DDL,CREATE TABLE,,,"CREATE TABLE do_table (""weird name"" INT)",<none>,0
+NOTICE:  AUDIT: SESSION,90,3,DDL,DROP TABLE,,,DROP table do_table,<none>,0
+--
+-- Generate an error and make sure the stack gets cleared
+DO $$
+BEGIN
+	CREATE TABLE bogus.test_block
+	(
+		id INT
+	);
+END $$;
+NOTICE:  AUDIT: SESSION,91,1,FUNCTION,DO,,,"DO $$
+BEGIN
+	CREATE TABLE bogus.test_block
+	(
+		id INT
+	);
+END $$;",<none>,0
+ERROR:  schema "bogus" does not exist at character 14
+--
+-- Test alter table statements
+ALTER TABLE public.test
+	DROP COLUMN description ;
+NOTICE:  AUDIT: SESSION,92,1,DDL,ALTER TABLE,,,"ALTER TABLE public.test
+	DROP COLUMN description ;",<none>,0
+ALTER TABLE public.test
+	RENAME TO test2;
+NOTICE:  AUDIT: SESSION,93,1,DDL,ALTER TABLE,,,"ALTER TABLE public.test
+	RENAME TO test2;",<none>,0
+ALTER TABLE public.test2
+	SET SCHEMA test;
+NOTICE:  AUDIT: SESSION,94,1,DDL,ALTER TABLE,,,"ALTER TABLE public.test2
+	SET SCHEMA test;",<none>,0
+ALTER TABLE test.test2
+	ADD COLUMN description TEXT;
+NOTICE:  AUDIT: SESSION,95,1,DDL,ALTER TABLE,,,"ALTER TABLE test.test2
+	ADD COLUMN description TEXT;",<none>,0
+ALTER TABLE test.test2
+	DROP COLUMN description;
+NOTICE:  AUDIT: SESSION,96,1,DDL,ALTER TABLE,,,"ALTER TABLE test.test2
+	DROP COLUMN description;",<none>,0
+DROP TABLE test.test2;
+NOTICE:  AUDIT: SESSION,97,1,DDL,DROP TABLE,,,DROP TABLE test.test2;,<none>,0
+--
+-- Test multiple statements with one semi-colon
+CREATE SCHEMA foo1
+	CREATE TABLE foo1.bar1 (id int)
+	CREATE TABLE foo1.baz1 (id int);
+NOTICE:  AUDIT: SESSION,98,1,DDL,CREATE SCHEMA,,,"CREATE SCHEMA foo1
+	CREATE TABLE foo1.bar1 (id int)
+	CREATE TABLE foo1.baz1 (id int);",<none>,0
+DROP TABLE foo1.bar1;
+NOTICE:  AUDIT: SESSION,99,1,DDL,DROP TABLE,,,DROP TABLE foo1.bar1;,<none>,0
+DROP TABLE foo1.baz1;
+NOTICE:  AUDIT: SESSION,100,1,DDL,DROP TABLE,,,DROP TABLE foo1.baz1;,<none>,0
+DROP SCHEMA foo1;
+NOTICE:  AUDIT: SESSION,101,1,DDL,DROP SCHEMA,,,DROP SCHEMA foo1;,<none>,0
+--
+-- Test aggregate
+CREATE FUNCTION public.int_add1
+(
+	a INT,
+	b INT
+)
+	RETURNS INT LANGUAGE plpgsql AS $$
+BEGIN
+	return a + b;
+END $$;
+NOTICE:  AUDIT: SESSION,102,1,DDL,CREATE FUNCTION,,,"CREATE FUNCTION public.int_add1
+(
+	a INT,
+	b INT
+)
+	RETURNS INT LANGUAGE plpgsql AS $$
+BEGIN
+	return a + b;
+END $$;",<none>,0
+SELECT int_add1(1, 1);
+NOTICE:  AUDIT: SESSION,103,1,FUNCTION,EXECUTE,FUNCTION,public.int_add1,"SELECT int_add1(1, 1);",<none>,0
+NOTICE:  AUDIT: SESSION,103,2,READ,SELECT,,,"SELECT int_add1(1, 1);",<none>,1
+ int_add1 
+----------
+        2
+(1 row)
+
+CREATE AGGREGATE public.sum_test(INT) (SFUNC=public.int_add1, STYPE=INT, INITCOND='0');
+NOTICE:  AUDIT: SESSION,104,1,DDL,CREATE AGGREGATE,,,"CREATE AGGREGATE public.sum_test(INT) (SFUNC=public.int_add1, STYPE=INT, INITCOND='0');",<none>,0
+ALTER AGGREGATE public.sum_test(integer) RENAME TO sum_test3;
+NOTICE:  AUDIT: SESSION,105,1,DDL,ALTER AGGREGATE,,,ALTER AGGREGATE public.sum_test(integer) RENAME TO sum_test3;,<none>,0
+--
+-- Test conversion
+CREATE CONVERSION public.conversion_test FOR 'latin1' TO 'utf8' FROM pg_catalog.iso8859_1_to_utf8;
+NOTICE:  AUDIT: SESSION,106,1,DDL,CREATE CONVERSION,,,CREATE CONVERSION public.conversion_test FOR 'latin1' TO 'utf8' FROM pg_catalog.iso8859_1_to_utf8;,<none>,0
+ALTER CONVERSION public.conversion_test RENAME TO conversion_test3;
+NOTICE:  AUDIT: SESSION,107,1,DDL,ALTER CONVERSION,,,ALTER CONVERSION public.conversion_test RENAME TO conversion_test3;,<none>,0
+--
+-- Test create/alter/drop database
+CREATE DATABASE contrib_regression_pgaudit;
+NOTICE:  AUDIT: SESSION,108,1,DDL,CREATE DATABASE,,,CREATE DATABASE contrib_regression_pgaudit;,<none>,0
+ALTER DATABASE contrib_regression_pgaudit RENAME TO contrib_regression_pgaudit2;
+NOTICE:  AUDIT: SESSION,109,1,DDL,ALTER DATABASE,,,ALTER DATABASE contrib_regression_pgaudit RENAME TO contrib_regression_pgaudit2;,<none>,0
+DROP DATABASE contrib_regression_pgaudit2;
+NOTICE:  AUDIT: SESSION,110,1,DDL,DROP DATABASE,,,DROP DATABASE contrib_regression_pgaudit2;,<none>,0
+-- Test role as a substmt
+SET pgaudit.log = 'role';
+CREATE TABLE t ();
+CREATE ROLE alice;
+NOTICE:  AUDIT: SESSION,111,1,ROLE,CREATE ROLE,,,CREATE ROLE alice;,<none>,0
+CREATE SCHEMA foo3
+	GRANT SELECT
+	   ON public.t
+	   TO alice;
+drop table public.t;
+drop role alice;
+NOTICE:  AUDIT: SESSION,112,1,ROLE,DROP ROLE,,,drop role alice;,<none>,0
+--
+-- Test for non-empty stack error
+CREATE OR REPLACE FUNCTION get_test_id(_ret REFCURSOR) RETURNS REFCURSOR
+LANGUAGE plpgsql IMMUTABLE AS $$
+BEGIN
+    OPEN _ret FOR SELECT 200;
+    RETURN _ret;
+END $$;
+BEGIN;
+    SELECT get_test_id('_ret');
+ get_test_id 
+-------------
+ _ret
+(1 row)
+
+    SELECT get_test_id('_ret2');
+ get_test_id 
+-------------
+ _ret2
+(1 row)
+
+    FETCH ALL FROM _ret;
+ ?column? 
+----------
+      200
+(1 row)
+
+    FETCH ALL FROM _ret2;
+ ?column? 
+----------
+      200
+(1 row)
+
+    CLOSE _ret;
+    CLOSE _ret2;
+END;
+--
+-- Test that frees a memory context earlier than expected
+SET pgaudit.log = 'all';
+NOTICE:  AUDIT: SESSION,113,1,MISC,SET,,,SET pgaudit.log = 'all';,<none>,0
+CREATE FUNCTION test1()
+	RETURNS INT AS $$
+DECLARE
+	cur1 cursor for select * from hoge;
+	tmp int;
+BEGIN
+	OPEN cur1;
+	FETCH cur1 into tmp;
+	RETURN tmp;
+END $$
+LANGUAGE plpgsql ;
+NOTICE:  AUDIT: SESSION,114,1,DDL,CREATE FUNCTION,,,"CREATE FUNCTION test1()
+	RETURNS INT AS $$
+DECLARE
+	cur1 cursor for select * from hoge;
+	tmp int;
+BEGIN
+	OPEN cur1;
+	FETCH cur1 into tmp;
+	RETURN tmp;
+END $$
+LANGUAGE plpgsql ;",<none>,0
+SELECT test1();
+NOTICE:  AUDIT: SESSION,115,1,FUNCTION,EXECUTE,FUNCTION,public.test1,SELECT test1();,<none>,0
+NOTICE:  AUDIT: SESSION,115,2,READ,SELECT,,,SELECT test1();,<none>,1
+ test1 
+-------
+      
+(1 row)
+
+--
+-- Delete all rows then delete 1 row
+SET pgaudit.log = 'write';
+SET pgaudit.role = 'auditor';
+create table bar
+(
+	col int
+);
+grant delete
+   on bar
+   to auditor;
+insert into bar (col)
+		 values (1);
+NOTICE:  AUDIT: SESSION,116,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+		 values (1);",<none>,1
+delete from bar;
+NOTICE:  AUDIT: OBJECT,117,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>,1
+NOTICE:  AUDIT: SESSION,117,1,WRITE,DELETE,TABLE,public.bar,delete from bar;,<none>,1
+insert into bar (col)
+		 values (1);
+NOTICE:  AUDIT: SESSION,118,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
+		 values (1);",<none>,1
+delete from bar
+ where col = 1;
+NOTICE:  AUDIT: OBJECT,119,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+ where col = 1;",<none>,1
+NOTICE:  AUDIT: SESSION,119,1,WRITE,DELETE,TABLE,public.bar,"delete from bar
+ where col = 1;",<none>,1
+drop table bar;
+--
+-- Test that FK references do not log but triggers still do
+SET pgaudit.log = 'read, write';
+SET pgaudit.role TO 'auditor';
+CREATE TABLE aaa
+(
+	ID int primary key
+);
+CREATE TABLE bbb
+(
+	id int
+		references aaa(id)
+);
+CREATE FUNCTION bbb_insert1() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE bbb set id = new.id + 1;
+
+	RETURN new;
+END $$ LANGUAGE plpgsql;
+CREATE TRIGGER bbb_insert_trg1
+	AFTER INSERT ON bbb
+	FOR EACH ROW EXECUTE PROCEDURE bbb_insert1();
+GRANT SELECT, UPDATE
+   ON aaa
+   TO auditor;
+GRANT UPDATE
+   ON bbb
+   TO auditor;
+INSERT INTO aaa VALUES (generate_series(1,100));
+NOTICE:  AUDIT: SESSION,120,1,WRITE,INSERT,TABLE,public.aaa,"INSERT INTO aaa VALUES (generate_series(1,100));",<none>,100
+SET pgaudit.log_parameter TO OFF;
+INSERT INTO bbb VALUES (1);
+NOTICE:  AUDIT: OBJECT,121,1,WRITE,UPDATE,TABLE,public.bbb,UPDATE bbb set id = new.id + 1,<not logged>,1
+NOTICE:  AUDIT: SESSION,121,1,WRITE,UPDATE,TABLE,public.bbb,UPDATE bbb set id = new.id + 1,<not logged>,1
+NOTICE:  AUDIT: SESSION,121,2,WRITE,INSERT,TABLE,public.bbb,INSERT INTO bbb VALUES (1);,<not logged>,1
+SET pgaudit.log_parameter TO ON;
+DROP TABLE bbb;
+DROP TABLE aaa;
+--
+-- Test MISC
+SET pgaudit.log = 'misc';
+NOTICE:  AUDIT: SESSION,122,1,MISC,SET,,,SET pgaudit.log = 'misc';,<none>,0
+SET pgaudit.log_client = on;
+NOTICE:  AUDIT: SESSION,123,1,MISC,SET,,,SET pgaudit.log_client = on;,<none>,0
+SET pgaudit.log_relation = on;
+NOTICE:  AUDIT: SESSION,124,1,MISC,SET,,,SET pgaudit.log_relation = on;,<none>,0
+SET pgaudit.log_parameter = on;
+NOTICE:  AUDIT: SESSION,125,1,MISC,SET,,,SET pgaudit.log_parameter = on;,<none>,0
+CREATE ROLE alice;
+SET ROLE alice;
+NOTICE:  AUDIT: SESSION,126,1,MISC,SET,,,SET ROLE alice;,<none>,0
+CREATE TABLE t (a int, b text);
+SET search_path TO test, public;
+NOTICE:  AUDIT: SESSION,127,1,MISC,SET,,,"SET search_path TO test, public;",<none>,0
+INSERT INTO t VALUES (1, 'misc');
+VACUUM t;
+NOTICE:  AUDIT: SESSION,128,1,MISC,VACUUM,,,VACUUM t;,<none>,0
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,129,1,MISC,RESET,,,RESET ROLE;,<none>,0
+--
+-- Test MISC_SET
+SET pgaudit.log = 'MISC_SET';
+NOTICE:  AUDIT: SESSION,130,1,MISC,SET,,,SET pgaudit.log = 'MISC_SET';,<none>,0
+SET ROLE alice;
+NOTICE:  AUDIT: SESSION,131,1,MISC,SET,,,SET ROLE alice;,<none>,0
+SET search_path TO public;
+NOTICE:  AUDIT: SESSION,132,1,MISC,SET,,,SET search_path TO public;,<none>,0
+INSERT INTO t VALUES (2, 'misc_set');
+VACUUM t;
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,133,1,MISC,RESET,,,RESET ROLE;,<none>,0
+--
+-- Test ALL, -MISC, MISC_SET
+SET pgaudit.log = 'ALL, -MISC, MISC_SET';
+NOTICE:  AUDIT: SESSION,134,1,MISC,SET,,,"SET pgaudit.log = 'ALL, -MISC, MISC_SET';",<none>,0
+SET search_path TO public;
+NOTICE:  AUDIT: SESSION,135,1,MISC,SET,,,SET search_path TO public;,<none>,0
+INSERT INTO t VALUES (3, 'all, -misc, misc_set');
+NOTICE:  AUDIT: SESSION,136,1,WRITE,INSERT,TABLE,public.t,"INSERT INTO t VALUES (3, 'all, -misc, misc_set');",<none>,1
+VACUUM t;
+RESET ROLE;
+NOTICE:  AUDIT: SESSION,137,1,MISC,RESET,,,RESET ROLE;,<none>,0
+DROP TABLE public.t;
+NOTICE:  AUDIT: SESSION,138,1,DDL,DROP TABLE,,,DROP TABLE public.t;,<none>,0
+DROP ROLE alice;
+NOTICE:  AUDIT: SESSION,139,1,ROLE,DROP ROLE,,,DROP ROLE alice;,<none>,0
+--
+-- Test PARTITIONED table
+CREATE TABLE h(x int ,y int) PARTITION BY HASH(x);
+NOTICE:  AUDIT: SESSION,140,1,DDL,CREATE TABLE,,,"CREATE TABLE h(x int ,y int) PARTITION BY HASH(x);",<none>,0
+CREATE TABLE h_0 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 0);
+NOTICE:  AUDIT: SESSION,141,1,DDL,CREATE TABLE,,,"CREATE TABLE h_0 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 0);",<none>,0
+CREATE TABLE h_1 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 1);
+NOTICE:  AUDIT: SESSION,142,1,DDL,CREATE TABLE,,,"CREATE TABLE h_1 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 1);",<none>,0
+INSERT INTO h VALUES(1,1);
+NOTICE:  AUDIT: SESSION,143,1,WRITE,INSERT,TABLE,public.h,"INSERT INTO h VALUES(1,1);",<none>,1
+SELECT * FROM h;
+NOTICE:  AUDIT: SESSION,144,1,READ,SELECT,TABLE,public.h,SELECT * FROM h;,<none>,1
+ x | y 
+---+---
+ 1 | 1
+(1 row)
+
+SELECT * FROM h_0;
+NOTICE:  AUDIT: SESSION,145,1,READ,SELECT,TABLE,public.h_0,SELECT * FROM h_0;,<none>,1
+ x | y 
+---+---
+ 1 | 1
+(1 row)
+
+CREATE INDEX h_idx ON h (x);
+NOTICE:  AUDIT: SESSION,146,1,DDL,CREATE INDEX,,,CREATE INDEX h_idx ON h (x);,<none>,0
+DROP INDEX h_idx;
+NOTICE:  AUDIT: SESSION,147,1,DDL,DROP INDEX,,,DROP INDEX h_idx;,<none>,0
+DROP TABLE h;
+NOTICE:  AUDIT: SESSION,148,1,DDL,DROP TABLE,,,DROP TABLE h;,<none>,0
+--
+-- Change configuration of user 1 so that full statements are not logged
+\connect - :current_user
+ALTER ROLE user1 RESET pgaudit.log_relation;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log_relation;,<not logged>
+ALTER ROLE user1 RESET pgaudit.log;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log;,<not logged>
+ALTER ROLE user1 SET pgaudit.log_statement = OFF;
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_statement = OFF;,<not logged>
+ALTER ROLE user1 SET pgaudit.log_rows = on;
+NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_rows = on;,<not logged>
+\connect - user1
+--
+-- Logged but without full statement
+SELECT * FROM account;
+NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,<not logged>,<not logged>,3
+ id | name  | password | description 
+----+-------+----------+-------------
+  1 | user1 | HASH4    | yada, yada3
+  1 | user2 | HASH4    | yada, yada3
+  1 | user3 | HASH4    | yada, yada3
+(3 rows)
+
+--
+-- Change back to superuser to do exhaustive tests
+\connect - :current_user
 -- Cleanup
 -- Set client_min_messages up to warning to avoid noise
 SET client_min_messages = 'warning';

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -161,6 +161,14 @@ bool auditLogStatementOnce = false;
 char *auditRole = NULL;
 
 /*
+ * GUC variable for pgaudit.log_rows
+ *
+ * Administrators can choose if the rows retrieved or affected by a statement
+ * are included in the audit log.
+ */
+bool auditLogRows = false;
+
+/*
  * String constants for the audit log fields.
  */
 
@@ -225,6 +233,10 @@ typedef struct
     bool logged;                /* Track if we have logged this event, used
                                    post-ProcessUtility to make sure we log */
     bool statementLogged;       /* Track if we have logged the statement */
+    int64 rows;                 /* Track rows processed by the statement */
+    MemoryContext queryContext; /* Context for query tracking rows */
+    Oid auditOid;               /* Role running query tracking rows  */
+    List *rangeTabls;           /* Tables in query tracking rows */
 } AuditEvent;
 
 /*
@@ -401,6 +413,26 @@ stack_valid(int64 stackId)
              " not found - top of stack is " INT64_FORMAT "",
              stackId,
              auditEventStack == NULL ? (int64) -1 : auditEventStack->stackId);
+}
+
+/*
+ * Find an item on the stack by the specified query memory context.
+ */
+static AuditEventStackItem *
+stack_find_context(MemoryContext findContext)
+{
+    AuditEventStackItem *nextItem = auditEventStack;
+
+    /* Look through the stack for the stack entry by query memory context */
+    while (nextItem != NULL)
+    {
+        if (nextItem->auditEvent.queryContext == findContext)
+            break;
+
+        nextItem = nextItem->next;
+    }
+
+    return nextItem;
 }
 
 /*
@@ -723,6 +755,11 @@ log_audit_event(AuditEventStackItem *stackItem)
     else
         appendStringInfoString(&auditStr,
                                "<previously logged>,<previously logged>");
+
+    /* Log rows affected */
+    if (auditLogRows)
+        appendStringInfo(&auditStr, "," INT64_FORMAT,
+                         stackItem->auditEvent.rows);
 
     /*
      * Log the audit entry.  Note: use of INT64_FORMAT here is bad for
@@ -1239,6 +1276,9 @@ static ExecutorCheckPerms_hook_type next_ExecutorCheckPerms_hook = NULL;
 static ProcessUtility_hook_type next_ProcessUtility_hook = NULL;
 static object_access_hook_type next_object_access_hook = NULL;
 static ExecutorStart_hook_type next_ExecutorStart_hook = NULL;
+/* The following hook functions are required to get rows */
+static ExecutorRun_hook_type next_ExecutorRun_hook = NULL;
+static ExecutorEnd_hook_type next_ExecutorEnd_hook = NULL;
 
 /*
  * Hook ExecutorStart to get the query text and basic command type for queries
@@ -1308,8 +1348,14 @@ pgaudit_ExecutorStart_hook(QueryDesc *queryDesc, int eflags)
      * standard_ExecutorStart().
      */
     if (stackItem)
+    {
         MemoryContextSetParent(stackItem->contextAudit,
                                queryDesc->estate->es_query_cxt);
+
+        /* Set query context for tracking rows processed */
+        if (auditLogRows)
+            stackItem->auditEvent.queryContext = queryDesc->estate->es_query_cxt;
+    }
 }
 
 /*
@@ -1326,7 +1372,36 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
     /* Log DML if the audit role is valid or session logging is enabled */
     if ((auditOid != InvalidOid || auditLogBitmap != 0) &&
         !IsAbortedTransactionBlockState())
-        log_select_dml(auditOid, rangeTabls);
+    {
+        /* If auditLogRows is on, wait for rows processed to be set */ 
+        if (auditLogRows && auditEventStack != NULL)
+        {
+            /* Check if the top item is SELECT/INSERT for CREATE TABLE AS */
+            if (auditEventStack->auditEvent.commandTag == T_SelectStmt &&
+                auditEventStack->next != NULL &&
+                auditEventStack->next->auditEvent.command == CMDTAG_CREATE_TABLE_AS &&
+                auditEventStack->auditEvent.rangeTabls != NULL)
+            {
+                /*
+                 * First, log the INSERT event for CREATE TABLE AS here.
+                 * The SELECT event for CREATE TABLE AS will be logged
+                 * in pgaudit_ExecutorEnd_hook() later to get rows.
+                 */
+                log_select_dml(auditOid, rangeTabls);
+            }
+            else
+            {
+                /*
+                 * Save auditOid and rangeTabls to call log_select_dml()
+                 * in pgaudit_ExecutorEnd_hook() later.
+                 */
+                auditEventStack->auditEvent.auditOid = auditOid;
+                auditEventStack->auditEvent.rangeTabls = rangeTabls;
+            }
+        }
+        else
+            log_select_dml(auditOid, rangeTabls);
+    }
 
     /* Call the next hook function */
     if (next_ExecutorCheckPerms_hook &&
@@ -1334,6 +1409,67 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
         return false;
 
     return true;
+}
+
+/*
+ * Hook ExecutorRun to get rows processed by the current statement.
+ */
+static void
+pgaudit_ExecutorRun_hook(QueryDesc *queryDesc, ScanDirection direction, uint64 count, bool execute_once)
+{
+    AuditEventStackItem *stackItem = NULL;
+
+    /* Call the previous hook or standard function */
+    if (next_ExecutorRun_hook)
+        next_ExecutorRun_hook(queryDesc, direction, count, execute_once);
+    else
+        standard_ExecutorRun(queryDesc, direction, count, execute_once);
+
+    if (auditLogRows && !internalStatement)
+    {
+        /* Find an item from the stack by the query memory context */
+        stackItem = stack_find_context(queryDesc->estate->es_query_cxt);
+
+        /* Accumulate the number of rows processed */
+        if (stackItem != NULL)
+            stackItem->auditEvent.rows += queryDesc->estate->es_processed;
+    }
+}
+
+/*
+ * Hook ExecutorEnd to get rows processed by the current statement.
+ */
+static void
+pgaudit_ExecutorEnd_hook(QueryDesc *queryDesc)
+{
+    AuditEventStackItem *stackItem = NULL;
+    AuditEventStackItem *auditEventStackFull = NULL;
+
+    if (auditLogRows && !internalStatement)
+    {
+        /* Find an item from the stack by the query memory context */
+        stackItem = stack_find_context(queryDesc->estate->es_query_cxt);
+
+        if (stackItem != NULL && stackItem->auditEvent.rangeTabls != NULL)
+        {
+            /* Reset auditEventStack to use in log_select_dml() */
+            auditEventStackFull = auditEventStack;
+            auditEventStack = stackItem;
+
+            /* Log SELECT/DML audit entry */
+            log_select_dml(stackItem->auditEvent.auditOid,
+                           stackItem->auditEvent.rangeTabls);
+
+            /* Switch back to the previous auditEventStack */
+            auditEventStack = auditEventStackFull;
+        }
+    }
+
+    /* Call the previous hook or standard function */
+    if (next_ExecutorEnd_hook)
+        next_ExecutorEnd_hook(queryDesc);
+    else
+        standard_ExecutorEnd(queryDesc);
 }
 
 /*
@@ -2000,6 +2136,20 @@ _PG_init(void)
         GUC_NOT_IN_SAMPLE,
         NULL, NULL, NULL);
 
+    /* Define pgaudit.log_rows */
+    DefineCustomBoolVariable(
+        "pgaudit.log_rows",
+
+        "Specifies whether logging will include the rows retrieved or "
+        "affected by a statement.",
+
+        NULL,
+        &auditLogRows,
+        false,
+        PGC_SUSET,
+        GUC_NOT_IN_SAMPLE,
+        NULL, NULL, NULL);
+
     /*
      * Install our hook functions after saving the existing pointers to
      * preserve the chains.
@@ -2015,6 +2165,13 @@ _PG_init(void)
 
     next_object_access_hook = object_access_hook;
     object_access_hook = pgaudit_object_access_hook;
+
+    /* The following hook functions are required to get rows */
+    next_ExecutorRun_hook = ExecutorRun_hook;
+    ExecutorRun_hook = pgaudit_ExecutorRun_hook;
+
+    next_ExecutorEnd_hook = ExecutorEnd_hook;
+    ExecutorEnd_hook = pgaudit_ExecutorEnd_hook;
 
     /* Log that the extension has completed initialization */
 #ifndef EXEC_BACKEND

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1373,7 +1373,7 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, bool abort)
     if ((auditOid != InvalidOid || auditLogBitmap != 0) &&
         !IsAbortedTransactionBlockState())
     {
-        /* If auditLogRows is on, wait for rows processed to be set */ 
+        /* If auditLogRows is on, wait for rows processed to be set */
         if (auditLogRows && auditEventStack != NULL)
         {
             /* Check if the top item is SELECT/INSERT for CREATE TABLE AS */

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -135,6 +135,14 @@ bool auditLogParameter = false;
 bool auditLogRelation = false;
 
 /*
+ * GUC variable for pgaudit.log_rows
+ *
+ * Administrators can choose if the rows retrieved or affected by a statement
+ * are included in the audit log.
+ */
+bool auditLogRows = false;
+
+/*
  * GUC variable for pgaudit.log_statement
  *
  * Administrators can choose to not have the full statement text logged.
@@ -159,14 +167,6 @@ bool auditLogStatementOnce = false;
  * determine if a statement should be logged.
  */
 char *auditRole = NULL;
-
-/*
- * GUC variable for pgaudit.log_rows
- *
- * Administrators can choose if the rows retrieved or affected by a statement
- * are included in the audit log.
- */
-bool auditLogRows = false;
 
 /*
  * String constants for the audit log fields.
@@ -2086,6 +2086,20 @@ _PG_init(void)
         GUC_NOT_IN_SAMPLE,
         NULL, NULL, NULL);
 
+    /* Define pgaudit.log_rows */
+    DefineCustomBoolVariable(
+        "pgaudit.log_rows",
+
+        "Specifies whether logging will include the rows retrieved or "
+        "affected by a statement.",
+
+        NULL,
+        &auditLogRows,
+        false,
+        PGC_SUSET,
+        GUC_NOT_IN_SAMPLE,
+        NULL, NULL, NULL);
+
     /* Define pgaudit.log_statement */
     DefineCustomBoolVariable(
         "pgaudit.log_statement",
@@ -2132,20 +2146,6 @@ _PG_init(void)
         NULL,
         &auditRole,
         "",
-        PGC_SUSET,
-        GUC_NOT_IN_SAMPLE,
-        NULL, NULL, NULL);
-
-    /* Define pgaudit.log_rows */
-    DefineCustomBoolVariable(
-        "pgaudit.log_rows",
-
-        "Specifies whether logging will include the rows retrieved or "
-        "affected by a statement.",
-
-        NULL,
-        &auditLogRows,
-        false,
         PGC_SUSET,
         GUC_NOT_IN_SAMPLE,
         NULL, NULL, NULL);

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -997,7 +997,7 @@ DELETE
 
 DELETE
   FROM test3
- WHERE id > 0; 
+ WHERE id > 0;
 
 --
 -- Drop test tables

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -32,6 +32,7 @@ RESET pgaudit.log_level;
 --     STATEMENT - The statement being logged
 --     PARAMETER - If parameter logging is requested, they will follow the
 --                 statement
+--     ROWS - If rows logging is requested, they will follow the parameter
 
 SELECT current_user \gset
 
@@ -859,6 +860,681 @@ SELECT * FROM h_0;
 CREATE INDEX h_idx ON h (x);
 DROP INDEX h_idx;
 DROP TABLE h;
+
+--
+-- Test rows retrived or affected by statements
+\connect - :current_user
+
+SET pgaudit.log = 'all';
+SET pgaudit.log_client = on;
+SET pgaudit.log_relation = on;
+SET pgaudit.log_statement_once = off;
+SET pgaudit.log_parameter = on;
+SET pgaudit.log_rows = on;
+
+--
+-- Test DDL
+CREATE TABLE test2
+(
+	id int,
+	name text
+);
+
+CREATE TABLE test3
+(
+	id int,
+	name text
+);
+
+CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 90
+	 WHERE id = new.id;
+
+	RETURN new;
+END $$ LANGUAGE plpgsql security definer;
+
+CREATE TRIGGER test2_insert_trg
+	AFTER INSERT ON test2
+	FOR EACH ROW EXECUTE PROCEDURE test2_insert();
+
+CREATE FUNCTION test2_change(change_id int) RETURNS void AS $$
+BEGIN
+	UPDATE test2
+	   SET id = id + 1
+	 WHERE id = change_id;
+END $$ LANGUAGE plpgsql security definer;
+
+CREATE VIEW vw_test3 AS
+SELECT *
+  FROM test3;
+
+--
+-- Test DML
+INSERT INTO test2 (id, name)
+		  VALUES (1, 'a');
+INSERT INTO test2 (id, name)
+		  VALUES (2, 'b');
+INSERT INTO test2 (id, name)
+		  VALUES (3, 'c');
+
+INSERT INTO test3 (id, name)
+		  VALUES (1, 'a');
+INSERT INTO test3 (id, name)
+		  VALUES (2, 'b');
+INSERT INTO test3 (id, name)
+		  VALUES (3, 'c');
+
+SELECT *
+  FROM test3, test2;
+
+SELECT *
+  FROM vw_test3, test2;
+
+SELECT *
+  FROM test2
+ ORDER BY ID;
+
+UPDATE test2
+   SET name = 'd';
+
+UPDATE test3
+   SET name = 'd'
+ WHERE id > 0;
+
+SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	  LIMIT 3
+) SUBQUERY;
+
+WITH CTE AS
+(
+	SELECT id
+	  FROM test2
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;
+
+WITH CTE AS
+(
+	INSERT INTO test3 VALUES (1)
+				   RETURNING id
+)
+INSERT INTO test2
+SELECT id
+  FROM cte;
+
+DO $$ BEGIN PERFORM test2_change(91); END $$;
+
+WITH CTE AS
+(
+	UPDATE test2
+	   SET id = 45
+	 WHERE id = 92
+	RETURNING id
+)
+INSERT INTO test3
+SELECT id
+  FROM cte;
+
+WITH CTE AS
+(
+	INSERT INTO test2 VALUES (37)
+				   RETURNING id
+)
+UPDATE test3
+   SET id = cte.id
+  FROM cte
+ WHERE test3.id <> cte.id;
+
+DELETE
+  FROM test2;
+
+DELETE
+  FROM test3
+ WHERE id > 0; 
+
+--
+-- Drop test tables
+DROP TABLE test2;
+DROP VIEW vw_test3;
+DROP TABLE test3;
+DROP FUNCTION test2_insert();
+DROP FUNCTION test2_change(int);
+
+--
+-- Only object logging will be done
+SET pgaudit.log = 'none';
+SET pgaudit.role = 'auditor';
+
+--
+-- Select is session logged
+SELECT *
+  FROM account;
+
+--
+-- Insert is not logged
+INSERT INTO account (id, name, password, description)
+			 VALUES (1, 'user2', 'HASH3', 'blah, blah2');
+INSERT INTO account (id, name, password, description)
+			 VALUES (1, 'user3', 'HASH4', 'blah, blah3');
+
+--
+-- Not object logged
+SELECT id,
+	   name
+  FROM account;
+
+--
+-- Object logged because of:
+-- select (password) on account
+SELECT password
+  FROM account;
+
+--
+-- Not object logged
+UPDATE account
+   SET description = 'yada, yada1';
+
+--
+-- Object logged because of:
+-- update (password) on account
+UPDATE account
+   SET password = 'HASH4';
+
+--
+-- Session relation logging will be done
+SET pgaudit.log_relation = on;
+SET pgaudit.log = 'read, write';
+
+--
+-- Object logged because of:
+-- select (password) on account
+-- select on account_role_map
+-- Session logged on all tables because log = read and log_relation = on
+SELECT account.password,
+	   account_role_map.role_id
+  FROM account
+	   INNER JOIN account_role_map
+			on account.id = account_role_map.account_id;
+
+--
+-- Object logged because of:
+-- select (password) on account
+-- Session logged on all tables because log = read and log_relation = on
+SELECT password
+  FROM account;
+
+--
+-- Not object logged
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET description = 'yada, yada2';
+
+--
+-- Object logged because of:
+-- select (password) on account (in the where clause)
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET description = 'yada, yada3'
+ where password = 'HASH4';
+
+--
+-- Object logged because of:
+-- update (password) on account
+-- Session logged on all tables because log = read and log_relation = on
+UPDATE account
+   SET password = 'HASH4';
+
+--
+-- Exhaustive tests
+SET pgaudit.log = 'all';
+SET pgaudit.log_client = on;
+SET pgaudit.log_relation = on;
+SET pgaudit.log_parameter = on;
+SET pgaudit.log_rows = on;
+
+--
+-- Simple DO block
+DO $$
+BEGIN
+	raise notice 'test';
+END $$;
+
+--
+-- Copy account to stdout
+COPY account TO stdout;
+
+--
+-- Drop a table from a query
+DROP TABLE test.account_copy;
+
+--
+-- Create a table from a query
+CREATE TABLE test.account_copy AS
+SELECT *
+  FROM account;
+
+--
+-- Copy from stdin to account copy
+COPY test.account_copy from stdin;
+1	user1	HASH4	yada, yada4
+\.
+
+--
+-- Test prepared statement
+PREPARE pgclassstmt1 (oid) AS
+SELECT 1
+  FROM account
+ WHERE id = $1;
+
+PREPARE pgclassstmt2 (oid) AS
+SELECT 2
+  FROM account
+ WHERE id = $1;
+
+EXECUTE pgclassstmt2 (1);
+EXECUTE pgclassstmt1 (1);
+
+DEALLOCATE pgclassstmt2;
+DEALLOCATE pgclassstmt1;
+
+--
+-- Test cursor
+BEGIN;
+
+DECLARE ctest1 SCROLL CURSOR FOR
+SELECT 1
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;
+
+DECLARE ctest2 SCROLL CURSOR FOR
+SELECT 2
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 3
+ ) subquery;
+
+FETCH NEXT FROM ctest1;
+FETCH NEXT FROM ctest2;
+FETCH NEXT FROM ctest1;
+FETCH NEXT FROM ctest2;
+FETCH NEXT FROM ctest1;
+FETCH NEXT FROM ctest2;
+
+CLOSE ctest2;
+CLOSE ctest1;
+COMMIT;
+
+--
+-- Turn off log_catalog and pg_class will not be logged
+SET pgaudit.log_catalog = off;
+
+SELECT count(*)
+  FROM
+(
+	SELECT relname
+	  FROM pg_class
+	 LIMIT 1
+ ) subquery;
+
+--
+-- Test prepared insert
+DROP TABLE test.test_insert;
+
+--
+-- Test prepared insert
+CREATE TABLE test.test_insert
+(
+	id INT
+);
+
+PREPARE pgclassstmt (oid) AS
+INSERT INTO test.test_insert (id)
+					  VALUES ($1);
+EXECUTE pgclassstmt (1);
+
+--
+-- Check that primary key creation is logged
+CREATE TABLE public.test
+(
+	id INT,
+	name TEXT,
+	description TEXT,
+	CONSTRAINT test_pkey PRIMARY KEY (id)
+);
+
+--
+-- Check that analyze is logged
+ANALYZE test;
+
+--
+-- Grants to public should not cause object logging (session logging will
+-- still happen)
+GRANT SELECT
+  ON TABLE public.test
+  TO PUBLIC;
+
+SELECT *
+  FROM test;
+
+-- Check that statements without columns log
+SELECT
+  FROM test;
+
+SELECT 1,
+	   substring('Thomas' from 2 for 3);
+
+DO $$
+DECLARE
+	test INT;
+BEGIN
+	SELECT 1
+	  INTO test;
+END $$;
+
+explain select 1;
+
+--
+-- Test that looks inside of do blocks log
+INSERT INTO TEST (id)
+		  VALUES (1);
+INSERT INTO TEST (id)
+		  VALUES (2);
+INSERT INTO TEST (id)
+		  VALUES (3);
+
+DO $$
+DECLARE
+	result RECORD;
+BEGIN
+	FOR result IN
+		SELECT id
+		  FROM test
+	LOOP
+		INSERT INTO test (id)
+			 VALUES (result.id + 100);
+	END LOOP;
+END $$;
+
+--
+-- Test obfuscated dynamic sql for clean logging
+DO $$
+DECLARE
+	table_name TEXT = 'do_table';
+BEGIN
+	EXECUTE 'CREATE TABLE ' || table_name || ' ("weird name" INT)';
+	EXECUTE 'DROP table ' || table_name;
+END $$;
+
+--
+-- Generate an error and make sure the stack gets cleared
+DO $$
+BEGIN
+	CREATE TABLE bogus.test_block
+	(
+		id INT
+	);
+END $$;
+
+--
+-- Test alter table statements
+ALTER TABLE public.test
+	DROP COLUMN description ;
+
+ALTER TABLE public.test
+	RENAME TO test2;
+
+ALTER TABLE public.test2
+	SET SCHEMA test;
+
+ALTER TABLE test.test2
+	ADD COLUMN description TEXT;
+
+ALTER TABLE test.test2
+	DROP COLUMN description;
+
+DROP TABLE test.test2;
+
+--
+-- Test multiple statements with one semi-colon
+CREATE SCHEMA foo1
+	CREATE TABLE foo1.bar1 (id int)
+	CREATE TABLE foo1.baz1 (id int);
+
+DROP TABLE foo1.bar1;
+DROP TABLE foo1.baz1;
+DROP SCHEMA foo1;
+
+--
+-- Test aggregate
+CREATE FUNCTION public.int_add1
+(
+	a INT,
+	b INT
+)
+	RETURNS INT LANGUAGE plpgsql AS $$
+BEGIN
+	return a + b;
+END $$;
+
+SELECT int_add1(1, 1);
+
+CREATE AGGREGATE public.sum_test(INT) (SFUNC=public.int_add1, STYPE=INT, INITCOND='0');
+ALTER AGGREGATE public.sum_test(integer) RENAME TO sum_test3;
+
+--
+-- Test conversion
+CREATE CONVERSION public.conversion_test FOR 'latin1' TO 'utf8' FROM pg_catalog.iso8859_1_to_utf8;
+ALTER CONVERSION public.conversion_test RENAME TO conversion_test3;
+
+--
+-- Test create/alter/drop database
+CREATE DATABASE contrib_regression_pgaudit;
+ALTER DATABASE contrib_regression_pgaudit RENAME TO contrib_regression_pgaudit2;
+DROP DATABASE contrib_regression_pgaudit2;
+
+-- Test role as a substmt
+SET pgaudit.log = 'role';
+
+CREATE TABLE t ();
+CREATE ROLE alice;
+
+CREATE SCHEMA foo3
+	GRANT SELECT
+	   ON public.t
+	   TO alice;
+
+drop table public.t;
+drop role alice;
+
+--
+-- Test for non-empty stack error
+CREATE OR REPLACE FUNCTION get_test_id(_ret REFCURSOR) RETURNS REFCURSOR
+LANGUAGE plpgsql IMMUTABLE AS $$
+BEGIN
+    OPEN _ret FOR SELECT 200;
+    RETURN _ret;
+END $$;
+
+BEGIN;
+    SELECT get_test_id('_ret');
+    SELECT get_test_id('_ret2');
+    FETCH ALL FROM _ret;
+    FETCH ALL FROM _ret2;
+    CLOSE _ret;
+    CLOSE _ret2;
+END;
+
+--
+-- Test that frees a memory context earlier than expected
+SET pgaudit.log = 'all';
+
+CREATE FUNCTION test1()
+	RETURNS INT AS $$
+DECLARE
+	cur1 cursor for select * from hoge;
+	tmp int;
+BEGIN
+	OPEN cur1;
+	FETCH cur1 into tmp;
+	RETURN tmp;
+END $$
+LANGUAGE plpgsql ;
+
+SELECT test1();
+
+--
+-- Delete all rows then delete 1 row
+SET pgaudit.log = 'write';
+SET pgaudit.role = 'auditor';
+
+create table bar
+(
+	col int
+);
+
+grant delete
+   on bar
+   to auditor;
+
+insert into bar (col)
+		 values (1);
+delete from bar;
+
+insert into bar (col)
+		 values (1);
+delete from bar
+ where col = 1;
+
+drop table bar;
+
+--
+-- Test that FK references do not log but triggers still do
+SET pgaudit.log = 'read, write';
+SET pgaudit.role TO 'auditor';
+
+CREATE TABLE aaa
+(
+	ID int primary key
+);
+
+CREATE TABLE bbb
+(
+	id int
+		references aaa(id)
+);
+
+CREATE FUNCTION bbb_insert1() RETURNS TRIGGER AS $$
+BEGIN
+	UPDATE bbb set id = new.id + 1;
+
+	RETURN new;
+END $$ LANGUAGE plpgsql;
+
+CREATE TRIGGER bbb_insert_trg1
+	AFTER INSERT ON bbb
+	FOR EACH ROW EXECUTE PROCEDURE bbb_insert1();
+
+GRANT SELECT, UPDATE
+   ON aaa
+   TO auditor;
+
+GRANT UPDATE
+   ON bbb
+   TO auditor;
+
+INSERT INTO aaa VALUES (generate_series(1,100));
+
+SET pgaudit.log_parameter TO OFF;
+INSERT INTO bbb VALUES (1);
+SET pgaudit.log_parameter TO ON;
+
+DROP TABLE bbb;
+DROP TABLE aaa;
+
+--
+-- Test MISC
+SET pgaudit.log = 'misc';
+SET pgaudit.log_client = on;
+SET pgaudit.log_relation = on;
+SET pgaudit.log_parameter = on;
+
+CREATE ROLE alice;
+
+SET ROLE alice;
+CREATE TABLE t (a int, b text);
+SET search_path TO test, public;
+
+INSERT INTO t VALUES (1, 'misc');
+
+VACUUM t;
+RESET ROLE;
+
+--
+-- Test MISC_SET
+SET pgaudit.log = 'MISC_SET';
+
+SET ROLE alice;
+SET search_path TO public;
+
+INSERT INTO t VALUES (2, 'misc_set');
+
+VACUUM t;
+RESET ROLE;
+
+--
+-- Test ALL, -MISC, MISC_SET
+SET pgaudit.log = 'ALL, -MISC, MISC_SET';
+SET search_path TO public;
+
+INSERT INTO t VALUES (3, 'all, -misc, misc_set');
+
+VACUUM t;
+
+RESET ROLE;
+DROP TABLE public.t;
+DROP ROLE alice;
+
+--
+-- Test PARTITIONED table
+CREATE TABLE h(x int ,y int) PARTITION BY HASH(x);
+CREATE TABLE h_0 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 0);
+CREATE TABLE h_1 partition OF h FOR VALUES WITH ( MODULUS 2, REMAINDER 1);
+INSERT INTO h VALUES(1,1);
+SELECT * FROM h;
+SELECT * FROM h_0;
+CREATE INDEX h_idx ON h (x);
+DROP INDEX h_idx;
+DROP TABLE h;
+
+--
+-- Change configuration of user 1 so that full statements are not logged
+\connect - :current_user
+ALTER ROLE user1 RESET pgaudit.log_relation;
+ALTER ROLE user1 RESET pgaudit.log;
+ALTER ROLE user1 SET pgaudit.log_statement = OFF;
+ALTER ROLE user1 SET pgaudit.log_rows = on;
+\connect - user1
+
+--
+-- Logged but without full statement
+SELECT * FROM account;
+
+--
+-- Change back to superuser to do exhaustive tests
+\connect - :current_user
 
 -- Cleanup
 -- Set client_min_messages up to warning to avoid noise


### PR DESCRIPTION
If `pgaudit.log_rows` is set to on, the audit logging should include the rows retrieved or affected by statements.
When the rows field is present which will be included after the parameter field.
The default is `off`.