### PR TITLE
Add pgaudit.log_statement setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,12 @@ Specifies whether session audit logging should create a separate log entry for e
 
 The default is `off`.
 
+### pgaudit.log_statement
+
+Specifies whether logging will include the statement text and parameters (if enabled). Depending on requirements, an audit log might not require this and it will make the logs less verbose.
+
+The default is `on`.
+
 ### pgaudit.log_statement_once
 
 Specifies whether logging will include the statement text and parameters with the first log entry for a statement/substatement combination or with every entry. Disabling this setting will result in less verbose logging but may make it more difficult to determine the statement that generated a log entry, though the statement/substatement pair along with the process id should suffice to identify the statement text logged with a previous entry.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The default is `off`.
 
 ### pgaudit.log_statement
 
-Specifies whether logging will include the statement text and parameters (if enabled). Depending on requirements, an audit log might not require this and it will make the logs less verbose.
+Specifies whether logging will include the statement text and parameters (if enabled). Depending on requirements, an audit log might not require this and it makes the logs less verbose.
 
 The default is `on`.
 

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -569,6 +569,25 @@ NOTICE:  AUDIT: OBJECT,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 NOTICE:  AUDIT: SESSION,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
 --
+-- Change configuration of user 1 so that full statements are not logged
+\connect - :current_user
+ALTER ROLE user1 RESET pgaudit.log_relation;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log_relation;,<not logged>
+ALTER ROLE user1 RESET pgaudit.log;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log;,<not logged>
+ALTER ROLE user1 SET pgaudit.log_statement = OFF;
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_statement = OFF;,<not logged>
+\connect - user1
+--
+-- Logged but without full statement
+SELECT * FROM account;
+NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,<not logged>,<not logged>
+ id | name  | password | description 
+----+-------+----------+-------------
+  1 | user1 | HASH2    | yada, yada
+(1 row)
+
+--
 -- Change back to superuser to do exhaustive tests
 \connect - :current_user
 SET pgaudit.log = 'ALL';
@@ -1239,6 +1258,7 @@ ALTER ROLE :current_user RESET pgaudit.log_client;
 ALTER ROLE :current_user RESET pgaudit.log_level;
 ALTER ROLE :current_user RESET pgaudit.log_parameter;
 ALTER ROLE :current_user RESET pgaudit.log_relation;
+ALTER ROLE :current_user RESET pgaudit.log_statement;
 ALTER ROLE :current_user RESET pgaudit.log_statement_once;
 ALTER ROLE :current_user RESET pgaudit.role;
 RESET pgaudit.log;
@@ -1246,6 +1266,7 @@ RESET pgaudit.log_catalog;
 RESET pgaudit.log_level;
 RESET pgaudit.log_parameter;
 RESET pgaudit.log_relation;
+RESET pgaudit.log_statement;
 RESET pgaudit.log_statement_once;
 RESET pgaudit.role;
 DROP TABLE test.account_copy;

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -430,6 +430,18 @@ UPDATE account
    SET password = 'HASH2';
 
 --
+-- Change configuration of user 1 so that full statements are not logged
+\connect - :current_user
+ALTER ROLE user1 RESET pgaudit.log_relation;
+ALTER ROLE user1 RESET pgaudit.log;
+ALTER ROLE user1 SET pgaudit.log_statement = OFF;
+\connect - user1
+
+--
+-- Logged but without full statement
+SELECT * FROM account;
+
+--
 -- Change back to superuser to do exhaustive tests
 \connect - :current_user
 SET pgaudit.log = 'ALL';
@@ -858,6 +870,7 @@ ALTER ROLE :current_user RESET pgaudit.log_client;
 ALTER ROLE :current_user RESET pgaudit.log_level;
 ALTER ROLE :current_user RESET pgaudit.log_parameter;
 ALTER ROLE :current_user RESET pgaudit.log_relation;
+ALTER ROLE :current_user RESET pgaudit.log_statement;
 ALTER ROLE :current_user RESET pgaudit.log_statement_once;
 ALTER ROLE :current_user RESET pgaudit.role;
 
@@ -866,6 +879,7 @@ RESET pgaudit.log_catalog;
 RESET pgaudit.log_level;
 RESET pgaudit.log_parameter;
 RESET pgaudit.log_relation;
+RESET pgaudit.log_statement;
 RESET pgaudit.log_statement_once;
 RESET pgaudit.role;
 


### PR DESCRIPTION
This setting, when turned off (not default), turns off all logging of
the full statement text and parameters.  This is analogous to
log_statement_once, except it never logs the statement.

Depending on requirements, the full statement text might not be
required in the audit log.  The combination of command tag and object
can be enough.  Omitting the full statement text makes the logs less
verbose and can also prevent some accidental information leaks.