### PR TITLE
Add security definer and set search_path on event trigger functions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MODULE_big = pgaudit
 OBJS = pgaudit.o $(WIN32RES)
 
 EXTENSION = pgaudit
-DATA = pgaudit--1.6.sql
+DATA = pgaudit--1.6.1.sql pgaudit--1.6--1.6.1.sql
 PGFILEDESC = "pgAudit - An audit logging extension for PostgreSQL"
 
 REGRESS = pgaudit

--- a/pgaudit--1.6--1.6.1.sql
+++ b/pgaudit--1.6--1.6.1.sql
@@ -1,0 +1,32 @@
+-- complain if script is sourced in psql, rather than via CREATE EXTENSION
+\echo Use "CREATE EXTENSION pgaudit" to load this file.\quit
+
+-- Drop old triggers and functions
+drop event trigger if exists pgaudit_ddl_command_end;
+drop function if exists pgaudit_ddl_command_end();
+
+drop event trigger if exists pgaudit_sql_drop;
+drop function if exists pgaudit_sql_drop();
+
+-- Create triggers and functions with security definer and search_path
+CREATE FUNCTION pgaudit_ddl_command_end()
+	RETURNS event_trigger
+	SECURITY DEFINER
+	SET search_path = 'pg_catalog, pg_temp'
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end';
+
+CREATE EVENT TRIGGER pgaudit_ddl_command_end
+	ON ddl_command_end
+	EXECUTE PROCEDURE pgaudit_ddl_command_end();
+
+CREATE FUNCTION pgaudit_sql_drop()
+	RETURNS event_trigger
+	SECURITY DEFINER
+	SET search_path = 'pg_catalog, pg_temp'
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop';
+
+CREATE EVENT TRIGGER pgaudit_sql_drop
+	ON sql_drop
+	EXECUTE PROCEDURE pgaudit_sql_drop();

--- a/pgaudit--1.6.1.sql
+++ b/pgaudit--1.6.1.sql
@@ -4,7 +4,7 @@
 CREATE FUNCTION pgaudit_ddl_command_end()
 	RETURNS event_trigger
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog'
+	SET search_path = 'pg_catalog, pg_temp'
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end';
 
@@ -15,7 +15,7 @@ CREATE EVENT TRIGGER pgaudit_ddl_command_end
 CREATE FUNCTION pgaudit_sql_drop()
 	RETURNS event_trigger
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog'
+	SET search_path = 'pg_catalog, pg_temp'
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop';
 

--- a/pgaudit--1.6.sql
+++ b/pgaudit--1.6.sql
@@ -3,10 +3,10 @@
 
 CREATE FUNCTION pgaudit_ddl_command_end()
 	RETURNS event_trigger
-	LANGUAGE C
-	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end'
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog';
+	SET search_path = 'pg_catalog'
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end';
 
 CREATE EVENT TRIGGER pgaudit_ddl_command_end
 	ON ddl_command_end
@@ -14,10 +14,10 @@ CREATE EVENT TRIGGER pgaudit_ddl_command_end
 
 CREATE FUNCTION pgaudit_sql_drop()
 	RETURNS event_trigger
-	LANGUAGE C
-	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop'
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog';
+	SET search_path = 'pg_catalog'
+	LANGUAGE C
+	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop';
 
 CREATE EVENT TRIGGER pgaudit_sql_drop
 	ON sql_drop

--- a/pgaudit--1.6.sql
+++ b/pgaudit--1.6.sql
@@ -4,7 +4,9 @@
 CREATE FUNCTION pgaudit_ddl_command_end()
 	RETURNS event_trigger
 	LANGUAGE C
-	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end';
+	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end'
+	SECURITY DEFINER
+	SET search_path = 'pg_catalog';
 
 CREATE EVENT TRIGGER pgaudit_ddl_command_end
 	ON ddl_command_end
@@ -13,7 +15,9 @@ CREATE EVENT TRIGGER pgaudit_ddl_command_end
 CREATE FUNCTION pgaudit_sql_drop()
 	RETURNS event_trigger
 	LANGUAGE C
-	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop';
+	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop'
+	SECURITY DEFINER
+	SET search_path = 'pg_catalog';
 
 CREATE EVENT TRIGGER pgaudit_sql_drop
 	ON sql_drop

--- a/pgaudit.control
+++ b/pgaudit.control
@@ -1,5 +1,5 @@
 # pgaudit extension
 comment = 'provides auditing functionality'
-default_version = '1.6'
+default_version = '1.6.1'
 module_pathname = '$libdir/pgaudit'
 relocatable = true


### PR DESCRIPTION
Similar to #156, this prevents users from defining their own versions of functions used in the event triggers.