### PR TITLE
Allow all cursors if current user is superuser

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1517,7 +1517,8 @@ pgaudit_ProcessUtility_hook(PlannedStmt *pstmt,
 
                 do
                 {
-                    if (nextItem->auditEvent.commandTag != T_SelectStmt &&
+                    if (!superuser() &&
+                        nextItem->auditEvent.commandTag != T_SelectStmt &&
                         nextItem->auditEvent.commandTag != T_VariableShowStmt &&
                         nextItem->auditEvent.commandTag != T_ExplainStmt)
                     {


### PR DESCRIPTION
When using pgaudit together with the pgextwlist extension and its
`before-create.sql` and `after-create.sql` hooks, creating extensions
fails with the error message

```
pgaudit stack is not empty
```

The pgextwlist creates extensions using superuser privileges even if the
current user is not superuser.

To reproduce the error:

1. install pgextwlist extension and add pgaudit to
the `shared_preload_libraries` PG server configuration.

2. allowlist an extension using pgextwlist, e.g. postgis

3. create a 'before-create.sql' file that uses statement that do not
belong to the `T_SelectStmt`, `T_VariableShowStmt` or `T_ExplainStmt`
categories, e.g.

```
CREATE SCHEMA IF NOT EXISTS test;
SET search_path to test;
```

This commit allows all cursors if the current user is superuser and the
stack is not empty.

Issue: https://github.com/pgaudit/pgaudit/issues/188