### PR TITLE
Add log_parameter_max_size to set maximum size of logged parameters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,8 @@ Autovacuum and Autoanalyze are not logged.
 
 Statements that are executed after a transaction enters an aborted state will not be audit logged. However, the statement that caused the error and any subsequent statements executed in the aborted transaction will be logged as ERRORs by the standard logging facility.
 
+It is not possible to reliably audit superusers with pgAudit. One solution is to restrict access to superuser accounts and use the [set_user](https://github.com/pgaudit/set_user) extension to escalate permissions when required.
+
 ## Authors
 
 The PostgreSQL Audit Extension is based on the [2ndQuadrant](http://www.2ndquadrant.com) [pgaudit project](https://github.com/2ndQuadrant/pgaudit) authored by Simon Riggs, Abhijit Menon-Sen, and Ian Barwick and submitted as an extension to PostgreSQL core. Additional development has been done by David Steele of [Crunchy Data](http://www.crunchydata.com).

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Specifies that audit logging should include the parameters that were passed with
 
 The default is `off`.
 
+### pgaudit.log_parameter_max_size
+
+Specifies that parameter values longer than this setting (in bytes) should not be logged, but replaced with `<long field suppressed>`. This is set in bytes, not characters, so does not account for multibyte characters in a text field's encoding. This parameter has no effect if `log_parameter` is `off`. If this setting is 0 (the default), all parameters are logged regardless of length
+
+The default is 0.
+
 ### pgaudit.log_relation
 
 Specifies whether session audit logging should create a separate log entry for each relation (`TABLE`, `VIEW`, etc.) referenced in a `SELECT` or `DML` statement. This is a useful shortcut for exhaustive logging without using object audit logging.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The default is `off`.
 
 ### pgaudit.log_parameter_max_size
 
-Specifies that parameter values longer than this setting (in bytes) should not be logged, but replaced with `<long field suppressed>`. This is set in bytes, not characters, so does not account for multibyte characters in a text field's encoding. This parameter has no effect if `log_parameter` is `off`. If this setting is 0 (the default), all parameters are logged regardless of length
+Specifies that parameter values longer than this setting (in bytes) should not be logged, but replaced with `<long param suppressed>`. This is set in bytes, not characters, so does not account for multi-byte characters in a text parameters's encoding. This setting has no effect if `log_parameter` is `off`. If this setting is 0 (the default), all parameters are logged regardless of length
 
 The default is 0.
 

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -394,7 +394,7 @@ PREPARE testinsert(int, text) AS
     INSERT INTO test4 VALUES($1, $2);
 EXECUTE testinsert(1, '*******************************************************');
 WARNING:  AUDIT: OBJECT,1,1,WRITE,INSERT,TABLE,public.test4,"PREPARE testinsert(int, text) AS
-    INSERT INTO test4 VALUES($1, $2);","1,<long field suppressed>"
+    INSERT INTO test4 VALUES($1, $2);","1,<long param suppressed>"
 DEALLOCATE testinsert;
 \connect - :current_user
 ALTER ROLE user2 RESET pgaudit.log_parameter_max_size;

--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -382,6 +382,34 @@ WARNING:  AUDIT: OBJECT,3,1,WRITE,UPDATE,TABLE,public.test4,"UPDATE public.test4
 update public.test4 set name = 'foo' where name = 'bar';
 WARNING:  AUDIT: OBJECT,4,1,WRITE,UPDATE,TABLE,public.test4,update public.test4 set name = 'foo' where name = 'bar';,<not logged>
 --
+-- Confirm that "long" parameter values will not be logged if pgaudit.log_parameter_max_size
+-- is set.
+\connect - :current_user
+ALTER ROLE user2 SET pgaudit.log_parameter_max_size = 50;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_parameter_max_size = 50;,<not logged>
+ALTER ROLE user2 SET pgaudit.log_parameter = 'on';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_parameter = 'on';,<not logged>
+\connect - user2
+PREPARE testinsert(int, text) AS
+    INSERT INTO test4 VALUES($1, $2);
+EXECUTE testinsert(1, '*******************************************************');
+WARNING:  AUDIT: OBJECT,1,1,WRITE,INSERT,TABLE,public.test4,"PREPARE testinsert(int, text) AS
+    INSERT INTO test4 VALUES($1, $2);","1,<long field suppressed>"
+DEALLOCATE testinsert;
+\connect - :current_user
+ALTER ROLE user2 RESET pgaudit.log_parameter_max_size;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 RESET pgaudit.log_parameter_max_size;,<not logged>
+\connect - user2
+PREPARE testinsert(int, text) AS
+    INSERT INTO test4 VALUES($1, $2);
+EXECUTE testinsert(2, '*******************************************************');
+WARNING:  AUDIT: OBJECT,1,1,WRITE,INSERT,TABLE,public.test4,"PREPARE testinsert(int, text) AS
+    INSERT INTO test4 VALUES($1, $2);","2,*******************************************************"
+DEALLOCATE testinsert;
+\connect - :current_user
+ALTER ROLE user2 RESET pgaudit.log_parameter;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 RESET pgaudit.log_parameter;,<not logged>
+--
 -- Change permissions of user 1 so that session logging will be done
 \connect - :current_user
 --
@@ -2538,6 +2566,7 @@ ALTER ROLE :current_user RESET pgaudit.log_catalog;
 ALTER ROLE :current_user RESET pgaudit.log_client;
 ALTER ROLE :current_user RESET pgaudit.log_level;
 ALTER ROLE :current_user RESET pgaudit.log_parameter;
+ALTER ROLE :current_user RESET pgaudit.log_parameter_max_size;
 ALTER ROLE :current_user RESET pgaudit.log_relation;
 ALTER ROLE :current_user RESET pgaudit.log_statement;
 ALTER ROLE :current_user RESET pgaudit.log_statement_once;
@@ -2546,6 +2575,7 @@ RESET pgaudit.log;
 RESET pgaudit.log_catalog;
 RESET pgaudit.log_level;
 RESET pgaudit.log_parameter;
+RESET pgaudit.log_parameter_max_size;
 RESET pgaudit.log_relation;
 RESET pgaudit.log_statement;
 RESET pgaudit.log_statement_once;

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -140,11 +140,11 @@ bool auditLogRelation = false;
  *
  * Adminsistrators can choose to prevent the logging of large variable-length
  * attributes.  If set to 0 (the default), all objects are logged.  If set
- * greater than 0, variable length objects larger (before character output)
- * whose size is greater than the specified number of bytes will be replaced
+ * greater than 0, variable length objects (before character output) whose
+ * size is greater than the specified number of bytes will be replaced
  * by a placeholder.
 */
-int auditMaxObjectSize = 0;
+int auditLogParameterMaxSize = 0;
 
 /*
  * GUC variable for pgaudit.log_rows
@@ -762,9 +762,9 @@ log_audit_event(AuditEventStackItem *stackItem)
                  */
                 getTypeOutputInfo(prm->ptype, &typeOutput, &typeIsVarLena);
 
-                if (auditMaxObjectSize &&
+                if (auditLogParameterMaxSize &&
                     typeIsVarLena &&
-                    VARSIZE_ANY_EXHDR(prm->value) > auditMaxObjectSize)
+                    VARSIZE_ANY_EXHDR(prm->value) > auditLogParameterMaxSize)
                     append_valid_csv(&paramStrResult, "<long field suppressed>");
                 else
                 {
@@ -2133,9 +2133,9 @@ _PG_init(void)
         GUC_NOT_IN_SAMPLE,
         NULL, NULL, NULL);
 
-    /* Define pgaudit.max_object_size */
+    /* Define pgaudit.log_parameter_max_size */
     DefineCustomIntVariable(
-        "pgaudit.max_object_size",
+        "pgaudit.log_parameter_max_size",
 
         "Specifies, in bytes, a maximum length of variable-length object to "
         "log.  If 0 (the default), objects are not checked for size.  If set, "
@@ -2145,7 +2145,7 @@ _PG_init(void)
         "characters.",
 
         NULL,
-        &auditMaxObjectSize,
+        &auditLogParameterMaxSize,
         0,
         0,
         (1 << 30) - 1,

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -141,7 +141,7 @@ bool auditLogRelation = false;
  * Adminsistrators can choose to prevent the logging of large variable-length
  * attributes.  If set to 0 (the default), all objects are logged.  If set
  * greater than 0, variable length objects larger (before character output)
- * whose size is  greater than the specified number of bytes will be replaced
+ * whose size is greater than the specified number of bytes will be replaced
  * by a placeholder.
 */
 int auditMaxObjectSize = 0;
@@ -771,7 +771,6 @@ log_audit_event(AuditEventStackItem *stackItem)
                     char *paramStr = OidOutputFunctionCall(typeOutput, prm->value);
 
                     append_valid_csv(&paramStrResult, paramStr);
-
                     pfree(paramStr);
                 }
             }
@@ -2139,16 +2138,17 @@ _PG_init(void)
         "pgaudit.max_object_size",
 
         "Specifies, in bytes, a maximum length of variable-length object to "
-        "log.  If 0 (the default), objects are not checked for size.  If set, if "
-        "the size of the object is longer than the setting, the value in the audit "
-        "log is replaced with a placeholder. Note hat for character types, the "
-        "length is in bytes in the field's encoding, not characters.",
+        "log.  If 0 (the default), objects are not checked for size.  If set, "
+        "when the size of the object is longer than the setting, the value in "
+        "the audit log is replaced with a placeholder. Note that for character "
+        "types, the length is in bytes for the field's encoding, not "
+        "characters.",
 
         NULL,
         &auditMaxObjectSize,
         0,
         0,
-        (1<<30)-1,
+        (1 << 30) - 1,
         PGC_SUSET,
         GUC_NOT_IN_SAMPLE,
         NULL, NULL, NULL);


### PR DESCRIPTION
This WIP PR addresses issue #186. It adds a new GUC, `pgaudit.max_object_size` (bikeshedding on name welcome). If non-zero, any parameter value whose storage representation is longer in bytes than that value is replaced by a placeholder, `<long field suppressed>`.  We use the storage format rather than (say) number of characters to avoid having to pull in, potentially decompress and character-encode or scan the value just to throw it away.

This PR doesn't contain test or doc fixes; those will be added once the code seems reasonable.