### PR TITLE
SELECT FOR UPDATE object logging improvement

### DIFF
--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -598,16 +598,30 @@ NOTICE:  AUDIT: SESSION,4,1,READ,SELECT,TABLE,public.account,"SELECT *
 (1 row)
 
 --
+-- Not object logged
+-- Session logged on all tables because log = read and log_relation = on
+SELECT name
+FROM account
+    FOR UPDATE;
+NOTICE:  AUDIT: SESSION,5,1,READ,SELECT,TABLE,public.account,"SELECT name
+FROM account
+    FOR UPDATE;",<not logged>
+ name  
+-------
+ user1
+(1 row)
+
+--
 -- Object logged because of:
 -- select (password) on account (in the where clause)
 -- Session logged on all tables because log = read and log_relation = on
 UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';
-NOTICE:  AUDIT: OBJECT,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,6,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';",<not logged>
-NOTICE:  AUDIT: SESSION,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: SESSION,6,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
    SET description = 'yada, yada'
  where password = 'HASH2';",<not logged>
 --
@@ -616,9 +630,9 @@ NOTICE:  AUDIT: SESSION,5,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 -- Session logged on all tables because log = read and log_relation = on
 UPDATE account
    SET password = 'HASH2';
-NOTICE:  AUDIT: OBJECT,6,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: OBJECT,7,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
-NOTICE:  AUDIT: SESSION,6,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
+NOTICE:  AUDIT: SESSION,7,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
    SET password = 'HASH2';",<not logged>
 --
 -- Change configuration of user 1 so that full statements are not logged

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1233,6 +1233,17 @@ log_select_dml(Oid auditOid, List *rangeTabls, List *permInfos)
                                                perminfo->updatedCols,
                                                auditPerms);
             }
+
+            /*
+             * SELECT FOR UPDATE is not logged when SELECT is not granted
+             */
+            if (rte->rellockmode == RowShareLock &&
+                !audit_on_relation(relOid, auditOid, ACL_SELECT)) {
+                auditEventStack->auditEvent.granted =
+                    audit_on_any_attribute(relOid, auditOid,
+                        perminfo->selectedCols,
+                        ACL_SELECT);
+            }
         }
 
         /* Do relation level logging if a grant was found */

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -457,6 +457,13 @@ SELECT *
    FOR UPDATE;
 
 --
+-- Not object logged
+-- Session logged on all tables because log = read and log_relation = on
+SELECT name
+FROM account
+    FOR UPDATE;
+
+--
 -- Object logged because of:
 -- select (password) on account (in the where clause)
 -- Session logged on all tables because log = read and log_relation = on


### PR DESCRIPTION
Don't log SELECT FOR UPDATE statements in object logs when there is no SELECT grant on the table and none of the columns that have SELECT grant are used.