### PR TITLE
Correction to docs for log_statement_once

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ The default is `on`.
 
 ### pgaudit.log_statement_once
 
-Specifies whether logging will include the statement text and parameters with the first log entry for a statement/substatement combination or with every entry. Disabling this setting will result in less verbose logging but may make it more difficult to determine the statement that generated a log entry, though the statement/substatement pair along with the process id should suffice to identify the statement text logged with a previous entry.
+Specifies whether logging will include the statement text and parameters with the first log entry for a statement/substatement combination or with every entry. Enabling this setting (`on`) will result in less verbose logging but may make it more difficult to determine the statement that generated a log entry, though the statement/substatement pair along with the process id should suffice to identify the statement text logged with a previous entry.
 
 The default is `off`.
 


### PR DESCRIPTION
The current documentation for log_statement_once has this backwards, so this is to change "disabled" to "enabled." 

Here's a test to demonstrate the functionality:

```
set pgaudit.log='all';
set pgaudit.log_parameter=on;
set pgaudit.log_relation=on;
set pgaudit.log_catalog=off;

set pgaudit.log_statement_once=off;
select name, birth_year from artists_sql where birth_year > (select birth_year from artists_sql where name='JoAnn Verburg') order by birth_year limit 10;

2023-12-01 07:38:36.541 EST [9653] LOG:  AUDIT: SESSION,44,1,READ,SELECT,TABLE,public.artists_sql,"select name, birth_year from artists_sql where birth_year > (select birth_year from artists_sql where name='JoAnn Verburg') order by birth_year limit 10;",<none>
2023-12-01 07:38:36.541 EST [9653] LOG:  AUDIT: SESSION,44,1,READ,SELECT,TABLE,public.artists_sql,"select name, birth_year from artists_sql where birth_year > (select birth_year from artists_sql where name='JoAnn Verburg') order by birth_year limit 10;",<none>

set pgaudit.log_statement_once=on;
select name, birth_year from artists_sql where birth_year > (select birth_year from artists_sql where name='JoAnn Verburg') order by birth_year limit 10;

2023-12-01 07:38:48.144 EST [9653] LOG:  AUDIT: SESSION,46,1,READ,SELECT,TABLE,public.artists_sql,"select name, birth_year from artists_sql where birth_year > (select birth_year from artists_sql where name='JoAnn Verburg') order by birth_year limit 10;",<none>
2023-12-01 07:38:48.144 EST [9653] LOG:  AUDIT: SESSION,46,1,READ,SELECT,TABLE,public.artists_sql,<previously logged>,<previously logged>
```