### PR TITLE
Solve another pgaudit stack is not empty error for 15 and older

### DIFF
--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -1410,8 +1410,6 @@ NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,TABLE,public.test2,"SELECT *
   FROM vw_test3, test2;",<none>,9
 NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,VIEW,public.vw_test3,"SELECT *
   FROM vw_test3, test2;",<none>,9
-NOTICE:  AUDIT: SESSION,20,1,MISC,???,VIEW,public.vw_test3,"SELECT *
-  FROM vw_test3, test2;",<none>,9
 NOTICE:  AUDIT: SESSION,20,1,READ,SELECT,TABLE,public.test3,"SELECT *
   FROM vw_test3, test2;",<none>,9
  id | name | id | name 

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1021,6 +1021,13 @@ log_select_dml(Oid auditOid, List *rangeTabls)
         if (rte->rtekind != RTE_RELATION)
             continue;
 
+		/*
+		 * Rewriter adds a second VIEW entry, with requiredPerms == 0,
+		 * to avoid permissions check for the second time.
+		 */
+		if (rte->relkind == RELKIND_VIEW && rte->requiredPerms == 0)
+			continue;
+
         found = true;
 
         /*


### PR DESCRIPTION
A test-case: https://github.com/pgaudit/pgaudit/issues/188#issuecomment-2124439104

The error happens because VIEW appears in the rtable for the second time. Below some debug information.

View with required SELECT permissions:
```
$2 = {type = T_RangeTblEntry, rtekind = RTE_RELATION, relid = 17403,
relkind = 118 'v', rellockmode = 1, tablesample = 0x0, subquery = 0x0,
security_barrier = false, jointype = JOIN_INNER, joinmergedcols = 0,
joinaliasvars = 0x0, joinleftcols = 0x0, joinrightcols = 0x0,
join_using_alias = 0x0, functions = 0x0, funcordinality = false,
tablefunc = 0x0, values_lists = 0x0, ctename = 0x0, ctelevelsup = 0,
self_reference = false, coltypes = 0x0, coltypmods = 0x0,
colcollations = 0x0, enrname = 0x0, enrtuples = 0,
alias = 0x5579b3f2e998, eref = 0x5579b3fe3390, lateral = false,
inh = false, inFromCl = false, requiredPerms = 2, checkAsUser = 0,
selectedCols = 0x0, insertedCols = 0x0, updatedCols = 0x0,
extraUpdatedCols = 0x0, securityQuals = 0x0}
```

The same view with requiredPerms = 0:
```
$3 = {type = T_RangeTblEntry, rtekind = RTE_RELATION, relid = 17403,
relkind = 118 'v', rellockmode = 1, tablesample = 0x0, subquery = 0x0,
security_barrier = false, jointype = JOIN_INNER, joinmergedcols = 0,
joinaliasvars = 0x0, joinleftcols = 0x0, joinrightcols = 0x0,
join_using_alias = 0x0, functions = 0x0, funcordinality = false,
tablefunc = 0x0, values_lists = 0x0, ctename = 0x0, ctelevelsup = 0,
self_reference = false, coltypes = 0x0, coltypmods = 0x0,
colcollations = 0x0, enrname = 0x0, enrtuples = 0,
alias = 0x5579b3fe35a0, eref = 0x5579b3fe35f8, lateral = false,
inh = false, inFromCl = false, requiredPerms = 0, checkAsUser = 16385,
selectedCols = 0x0, insertedCols = 0x0, updatedCols = 0x0,
extraUpdatedCols = 0x0, securityQuals = 0x0}
```

The problems doesn't happen with v16 and newer because there we rely on perminfoindex being set to `0`.