### PR TITLE
Add exception for call statement to stack check.

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1625,7 +1625,8 @@ pgaudit_ProcessUtility_hook(PlannedStmt *pstmt,
                 {
                     if (nextItem->auditEvent.commandTag != T_SelectStmt &&
                         nextItem->auditEvent.commandTag != T_VariableShowStmt &&
-                        nextItem->auditEvent.commandTag != T_ExplainStmt)
+                        nextItem->auditEvent.commandTag != T_ExplainStmt &&
+                        nextItem->auditEvent.commandTag != T_CallStmt)
                     {
                         elog(ERROR, "pgaudit stack is not empty");
                     }

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1614,8 +1614,8 @@ pgaudit_ProcessUtility_hook(PlannedStmt *pstmt,
         if (context == PROCESS_UTILITY_TOPLEVEL)
         {
             /*
-             * If the stack is not empty then the only allowed entries are open
-             * select, show, and explain cursors
+             * If the stack is not empty then the only allowed entries are call
+             * statements or open, select, show, and explain cursors
              */
             if (auditEventStack != NULL)
             {


### PR DESCRIPTION
Pull request https://github.com/pgaudit/pgaudit/pull/108 solved "pgaudit stack not empty" error by adding exception for select and explain.

One of our customers received the "stack not empty" error. After inspecting the case using logging statements, we discovered that a T_CallStmt was left in the stack when the error occurred.

We could reproduce the error related to calling of a stored procedure using the cursors with the following test case using Java code and the stored procedure definition given below:


```java
private static void testPgAuditStackNotEmpty(Connection conn)
    throws SQLException {

    try (Statement st = conn.createStatement()) {
        st.setFetchSize(1); // results in cursor being used

        try (final ResultSet rs =
            st.executeQuery("CALL sproc(1::bigint, 2::bigint)") )
        {
            Statement st2 = conn.createStatement();
            st2.execute("CREATE TABLE test5()"); //ERR: pgaudit stack not empty

            if (rs.next()) {
                System.out.println(rs.getString(1));
            }
        }
    }
}
```



```sql
    CREATE OR REPLACE PROCEDURE sproc(
        inarg BIGINT,
        OUT outarg BIGINT
    )
    LANGUAGE plpgsql
    AS $$
    BEGIN
        SELECT 1
        INTO outarg;
    END;
    $$;
```

T_CallStmt is can be added as an additional exception to fix this error. 

