### PR TITLE
Add auditEventStack null check in pgaudit_ExecutorCheckPerms_hook

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1514,7 +1514,7 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, List *permInfos, bool abort)
                 auditEventStack->auditEvent.permInfos = permInfos;
             }
         }
-        else
+        else if (auditEventStack != NULL)
             log_select_dml(auditOid, rangeTabls, permInfos);
     }
 


### PR DESCRIPTION
### Description

Fix crash in log_select_dml when called with an empty auditEventStack.
`log_select_dml` only logs an event after setting `auditEventStack->auditEvent.granted = false;` [here](https://github.com/pgaudit/pgaudit/blob/c214a2ead388c89a57254d82ac6be2b5292a0b4d/pgaudit.c#L1148) assuming auditEventStack to be non empty but some extensions could be calling `ExecCheckRTPerms` outside of executor or processUtility with an empty auditEventStack which results in NPE crash.
As a fix, always check for auditEventStack to be non empty in `pgaudit_ExecutorCheckPerms_hook` before calling `log_select_dml` and avoid the crash.

### Issues

https://github.com/pgaudit/pgaudit/issues/212

### Sign Off

Signed-off-by: Tanzeel Khan <tzlkhan@amazon.com>