### PR TITLE
Fix some compilation warnings

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -71,7 +71,7 @@ PG_FUNCTION_INFO_V1(pgaudit_sql_drop);
 #define LOG_ALL         (0xFFFFFFFF)    /* All */
 
 /* GUC variable for pgaudit.log, which defines the classes to log. */
-char *auditLog = NULL;
+static char *auditLog = NULL;
 
 /* Bitmap of classes selected */
 static int auditLogBitmap = LOG_NONE;
@@ -98,7 +98,7 @@ static int auditLogBitmap = LOG_NONE;
  * the query are in pg_catalog.  Interactive sessions (eg: psql) can cause
  * a lot of noise in the logs which might be uninteresting.
  */
-bool auditLogCatalog = true;
+static bool auditLogCatalog = true;
 
 /*
  * GUC variable for pgaudit.log_client
@@ -107,7 +107,7 @@ bool auditLogCatalog = true;
  * setting should generally be left disabled but may be useful for debugging or
  * other purposes.
  */
-bool auditLogClient = false;
+static bool auditLogClient = false;
 
 /*
  * GUC variable for pgaudit.log_level
@@ -116,8 +116,8 @@ bool auditLogClient = false;
  * at.  The default level is LOG, which goes into the server log but does
  * not go to the client.  Set to NOTICE in the regression tests.
  */
-char *auditLogLevelString = NULL;
-int auditLogLevel = LOG;
+static char *auditLogLevelString = NULL;
+static int auditLogLevel = LOG;
 
 /*
  * GUC variable for pgaudit.log_parameter
@@ -125,7 +125,7 @@ int auditLogLevel = LOG;
  * Administrators can choose if parameters passed into a statement are
  * included in the audit log.
  */
-bool auditLogParameter = false;
+static bool auditLogParameter = false;
 
 /*
  * GUC variable for pgaudit.log_relation
@@ -134,7 +134,7 @@ bool auditLogParameter = false;
  * in READ/WRITE class queries.  By default, SESSION logs include the query but
  * do not have a log entry for each relation.
  */
-bool auditLogRelation = false;
+static bool auditLogRelation = false;
 
 /*
  * GUC variable for pgaudit.log_parameter_max_size
@@ -145,7 +145,7 @@ bool auditLogRelation = false;
  * size is greater than the specified number of bytes will be replaced
  * by a placeholder.
 */
-int auditLogParameterMaxSize = 0;
+static int auditLogParameterMaxSize = 0;
 
 /*
  * GUC variable for pgaudit.log_rows
@@ -153,14 +153,14 @@ int auditLogParameterMaxSize = 0;
  * Administrators can choose if the rows retrieved or affected by a statement
  * are included in the audit log.
  */
-bool auditLogRows = false;
+static bool auditLogRows = false;
 
 /*
  * GUC variable for pgaudit.log_statement
  *
  * Administrators can choose to not have the full statement text logged.
  */
-bool auditLogStatement = true;
+static bool auditLogStatement = true;
 
 /*
  * GUC variable for pgaudit.log_statement_once
@@ -170,7 +170,7 @@ bool auditLogStatement = true;
  * the audit log to facilitate searching, but this can cause the log to be
  * unnecessarily bloated in some environments.
  */
-bool auditLogStatementOnce = false;
+static bool auditLogStatementOnce = false;
 
 /*
  * GUC variable for pgaudit.role
@@ -179,7 +179,7 @@ bool auditLogStatementOnce = false;
  * Object-level auditing uses the privileges which are granted to this role to
  * determine if a statement should be logged.
  */
-char *auditRole = NULL;
+static char *auditRole = NULL;
 
 /*
  * String constants for the audit log fields.
@@ -270,7 +270,7 @@ typedef struct AuditEventStackItem
     MemoryContextCallback contextCallback;
 } AuditEventStackItem;
 
-AuditEventStackItem *auditEventStack = NULL;
+static AuditEventStackItem *auditEventStack = NULL;
 
 /*
  * pgAudit runs queries of its own when using the event trigger system.


### PR DESCRIPTION
the GUC variables defined with a global declaration and are just used within pgaudit.c.  This was the cause of compilation warnings under -Wmissing-variable-declarations, for example.