### PR TITLE
Update .gitignore with more contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,29 @@
+# Regression tests
 log/
 results/
 tmp_check/
 regression.diffs
 regression.out
+
+# Coverage files
+*.gcno
+*.gcda
+
+# Libraries
+*.lib
+*.a
+
+# LLVM bitcode
 *.bc
+
+# Object files
 *.o
+
+# Shared objects (inc. Windows DLLs)
+*.dll
 *.so
+*.so.*
+*.dylib
+
+# Dependencies
+.deps


### PR DESCRIPTION
This adds more entries to the project's gitignore, ensuring that unwanted contents are not pushed into the tree:
- Coverage files.
- More object and library patterns
- LLVM code
- Dependencies