### PR TITLE
Avoid regression failures with ENFORCE_REGRESSION_TEST_NAME_RESTRICTIONS

### DIFF
--- a/expected/pgaudit.out
+++ b/expected/pgaudit.out
@@ -41,27 +41,27 @@ ALTER ROLE :current_user SET pgaudit.log_client = ON;
 \connect - :current_user;
 --
 -- Create auditor role
-CREATE ROLE auditor;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE auditor,<not logged>
+CREATE ROLE regress_auditor;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE regress_auditor,<not logged>
 --
 -- Create first test user
-CREATE USER user1 password 'password';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,CREATE ROLE,,,CREATE USER user1 password <REDACTED>,<not logged>
-ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE';
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,"ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE'",<not logged>
-ALTER ROLE user1 SET pgaudit.log_level = 'notice';
-NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_level = 'notice',<not logged>
-ALTER ROLE user1 PassWord 'password2' NOLOGIN;
-NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 PassWord <REDACTED>,<not logged>
-ALTER USER user1 encrypted /* random comment */PASSWORD
+CREATE USER regress_user1 password 'password';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,CREATE ROLE,,,CREATE USER regress_user1 password <REDACTED>,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log = 'ddl, ROLE';
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,"ALTER ROLE regress_user1 SET pgaudit.log = 'ddl, ROLE'",<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log_level = 'notice';
+NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_level = 'notice',<not logged>
+ALTER ROLE regress_user1 PassWord 'password2' NOLOGIN;
+NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 PassWord <REDACTED>,<not logged>
+ALTER USER regress_user1 encrypted /* random comment */PASSWORD
 	/* random comment */
     'md565cb1da342495ea6bb0418a6e5718c38' LOGIN;
-NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER USER user1 encrypted /* random comment */PASSWORD <REDACTED>,<not logged>
-ALTER ROLE user1 SET pgaudit.log_client = ON;
-NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_client = ON,<not logged>
+NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER USER regress_user1 encrypted /* random comment */PASSWORD <REDACTED>,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log_client = ON;
+NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_client = ON,<not logged>
 --
 -- Create, select, drop (select will not be audited)
-\connect - user1
+\connect - regress_user1
 CREATE TABLE public.test
 (
 	id INT
@@ -81,20 +81,20 @@ NOTICE:  AUDIT: SESSION,2,1,DDL,DROP TABLE,TABLE,public.test,DROP TABLE test,<no
 --
 -- Create second test user
 \connect - :current_user
-CREATE ROLE user2 LOGIN password 'password';
-NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE user2 LOGIN password <REDACTED>,<not logged>
-ALTER ROLE user2 SET pgaudit.log = 'Read, writE';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,"ALTER ROLE user2 SET pgaudit.log = 'Read, writE'",<not logged>
-ALTER ROLE user2 SET pgaudit.log_catalog = OFF;
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_catalog = OFF,<not logged>
-ALTER ROLE user2 SET pgaudit.log_client = ON;
-NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_client = ON,<not logged>
-ALTER ROLE user2 SET pgaudit.log_level = 'warning';
-NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_level = 'warning',<not logged>
-ALTER ROLE user2 SET pgaudit.role = auditor;
-NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.role = auditor,<not logged>
-ALTER ROLE user2 SET pgaudit.log_statement_once = ON;
-NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_statement_once = ON,<not logged>
+CREATE ROLE regress_user2 LOGIN password 'password';
+NOTICE:  AUDIT: SESSION,1,1,ROLE,CREATE ROLE,,,CREATE ROLE regress_user2 LOGIN password <REDACTED>,<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log = 'Read, writE';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,"ALTER ROLE regress_user2 SET pgaudit.log = 'Read, writE'",<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log_catalog = OFF;
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_catalog = OFF,<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log_client = ON;
+NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_client = ON,<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log_level = 'warning';
+NOTICE:  AUDIT: SESSION,5,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_level = 'warning',<not logged>
+ALTER ROLE regress_user2 SET pgaudit.role = regress_auditor;
+NOTICE:  AUDIT: SESSION,6,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.role = regress_auditor,<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log_statement_once = ON;
+NOTICE:  AUDIT: SESSION,7,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_statement_once = ON,<not logged>
 --
 -- Setup role-based tests
 CREATE TABLE test2
@@ -103,32 +103,32 @@ CREATE TABLE test2
 );
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test2
-   TO user2, user1;
+   TO regress_user2, regress_user1;
 NOTICE:  AUDIT: SESSION,8,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
    ON test2
-   TO user2, user1",<not logged>
+   TO regress_user2, regress_user1",<not logged>
 GRANT SELECT, UPDATE
    ON TABLE public.test2
-   TO auditor;
+   TO regress_auditor;
 NOTICE:  AUDIT: SESSION,9,1,ROLE,GRANT,TABLE,,"GRANT SELECT, UPDATE
    ON TABLE public.test2
-   TO auditor",<not logged>
+   TO regress_auditor",<not logged>
 CREATE TABLE test3
 (
 	id INT
 );
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test3
-   TO user2;
+   TO regress_user2;
 NOTICE:  AUDIT: SESSION,10,1,ROLE,GRANT,TABLE,,"GRANT SELECT, INSERT, UPDATE, DELETE
    ON test3
-   TO user2",<not logged>
+   TO regress_user2",<not logged>
 GRANT INSERT
    ON TABLE public.test3
-   TO auditor;
+   TO regress_auditor;
 NOTICE:  AUDIT: SESSION,11,1,ROLE,GRANT,TABLE,,"GRANT INSERT
    ON TABLE public.test3
-   TO auditor",<not logged>
+   TO regress_auditor",<not logged>
 CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
 BEGIN
 	UPDATE test2
@@ -137,7 +137,7 @@ BEGIN
 
 	RETURN new;
 END $$ LANGUAGE plpgsql security definer;
-ALTER FUNCTION test2_insert() OWNER TO user1;
+ALTER FUNCTION test2_insert() OWNER TO regress_user1;
 CREATE TRIGGER test2_insert_trg
 	AFTER INSERT ON test2
 	FOR EACH ROW EXECUTE PROCEDURE test2_insert();
@@ -147,23 +147,23 @@ BEGIN
 	   SET id = id + 1
 	 WHERE id = change_id;
 END $$ LANGUAGE plpgsql security definer;
-ALTER FUNCTION test2_change(int) OWNER TO user2;
+ALTER FUNCTION test2_change(int) OWNER TO regress_user2;
 CREATE VIEW vw_test3 AS
 SELECT *
   FROM test3;
 GRANT SELECT
    ON vw_test3
-   TO user2;
+   TO regress_user2;
 NOTICE:  AUDIT: SESSION,12,1,ROLE,GRANT,TABLE,,"GRANT SELECT
    ON vw_test3
-   TO user2",<not logged>
+   TO regress_user2",<not logged>
 GRANT SELECT
    ON vw_test3
-   TO auditor;
+   TO regress_auditor;
 NOTICE:  AUDIT: SESSION,13,1,ROLE,GRANT,TABLE,,"GRANT SELECT
    ON vw_test3
-   TO auditor",<not logged>
-\connect - user2
+   TO regress_auditor",<not logged>
+\connect - regress_user2
 --
 -- Role-based tests
 SELECT count(*)
@@ -315,9 +315,9 @@ WARNING:  AUDIT: OBJECT,8,1,READ,SELECT,TABLE,public.test2,<previously logged>,<
 --
 -- Change permissions of user 2 so that only object logging will be done
 \connect - :current_user
-ALTER ROLE user2 SET pgaudit.log = 'NONE';
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log = 'NONE',<not logged>
-\connect - user2
+ALTER ROLE regress_user2 SET pgaudit.log = 'NONE';
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log = 'NONE',<not logged>
+\connect - regress_user2
 --
 -- Create test4 and add permissions
 CREATE TABLE test4
@@ -327,13 +327,13 @@ CREATE TABLE test4
 );
 GRANT SELECT (name)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 GRANT UPDATE (id)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 GRANT insert (name)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 --
 -- Not object logged
 SELECT id
@@ -385,11 +385,11 @@ WARNING:  AUDIT: OBJECT,4,1,WRITE,UPDATE,TABLE,public.test4,update public.test4 
 -- Confirm that "long" parameter values will not be logged if pgaudit.log_parameter_max_size
 -- is set.
 \connect - :current_user
-ALTER ROLE user2 SET pgaudit.log_parameter_max_size = 50;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_parameter_max_size = 50,<not logged>
-ALTER ROLE user2 SET pgaudit.log_parameter = 'on';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 SET pgaudit.log_parameter = 'on',<not logged>
-\connect - user2
+ALTER ROLE regress_user2 SET pgaudit.log_parameter_max_size = 50;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_parameter_max_size = 50,<not logged>
+ALTER ROLE regress_user2 SET pgaudit.log_parameter = 'on';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 SET pgaudit.log_parameter = 'on',<not logged>
+\connect - regress_user2
 PREPARE testinsert(int, text) AS
     INSERT INTO test4 VALUES($1, $2);
 EXECUTE testinsert(1, '*******************************************************');
@@ -397,9 +397,9 @@ WARNING:  AUDIT: OBJECT,1,1,WRITE,INSERT,TABLE,public.test4,"PREPARE testinsert(
     INSERT INTO test4 VALUES($1, $2)","1,<long param suppressed>"
 DEALLOCATE testinsert;
 \connect - :current_user
-ALTER ROLE user2 RESET pgaudit.log_parameter_max_size;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 RESET pgaudit.log_parameter_max_size,<not logged>
-\connect - user2
+ALTER ROLE regress_user2 RESET pgaudit.log_parameter_max_size;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 RESET pgaudit.log_parameter_max_size,<not logged>
+\connect - regress_user2
 PREPARE testinsert(int, text) AS
     INSERT INTO test4 VALUES($1, $2);
 EXECUTE testinsert(2, '*******************************************************');
@@ -407,8 +407,8 @@ WARNING:  AUDIT: OBJECT,1,1,WRITE,INSERT,TABLE,public.test4,"PREPARE testinsert(
     INSERT INTO test4 VALUES($1, $2)","2,*******************************************************"
 DEALLOCATE testinsert;
 \connect - :current_user
-ALTER ROLE user2 RESET pgaudit.log_parameter;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user2 RESET pgaudit.log_parameter,<not logged>
+ALTER ROLE regress_user2 RESET pgaudit.log_parameter;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user2 RESET pgaudit.log_parameter,<not logged>
 --
 -- Change permissions of user 1 so that session logging will be done
 \connect - :current_user
@@ -420,9 +420,9 @@ DROP TABLE test3;
 DROP TABLE test4;
 DROP FUNCTION test2_insert();
 DROP FUNCTION test2_change(int);
-ALTER ROLE user1 SET pgaudit.log = 'DDL, READ';
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,"ALTER ROLE user1 SET pgaudit.log = 'DDL, READ'",<not logged>
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log = 'DDL, READ';
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,"ALTER ROLE regress_user1 SET pgaudit.log = 'DDL, READ'",<not logged>
+\connect - regress_user1
 --
 -- Create table is session logged
 CREATE TABLE public.account
@@ -452,29 +452,29 @@ NOTICE:  AUDIT: SESSION,2,1,READ,SELECT,,,"SELECT *
 --
 -- Insert is not logged
 INSERT INTO account (id, name, password, description)
-			 VALUES (1, 'user1', 'HASH1', 'blah, blah');
+			 VALUES (1, 'regress_user1', 'HASH1', 'blah, blah');
 --
 -- Change permissions of user 1 so that only object logging will be done
 \connect - :current_user
-ALTER ROLE user1 SET pgaudit.log = 'none';
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log = 'none',<not logged>
-ALTER ROLE user1 SET pgaudit.role = 'auditor';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.role = 'auditor',<not logged>
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log = 'none';
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log = 'none',<not logged>
+ALTER ROLE regress_user1 SET pgaudit.role = 'regress_auditor';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.role = 'regress_auditor',<not logged>
+\connect - regress_user1
 --
--- ROLE class not set, so auditor grants not logged
+-- ROLE class not set, so regress_auditor grants not logged
 GRANT SELECT (password),
 	  UPDATE (name, password)
    ON TABLE public.account
-   TO auditor;
+   TO regress_auditor;
 --
 -- Not object logged
 SELECT id,
 	   name
   FROM account;
- id | name  
-----+-------
-  1 | user1
+ id |     name      
+----+---------------
+  1 | regress_user1
 (1 row)
 
 --
@@ -503,11 +503,11 @@ NOTICE:  AUDIT: OBJECT,2,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 --
 -- Change permissions of user 1 so that session relation logging will be done
 \connect - :current_user
-ALTER ROLE user1 SET pgaudit.log_relation = on;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_relation = on,<not logged>
-ALTER ROLE user1 SET pgaudit.log = 'read, WRITE';
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,"ALTER ROLE user1 SET pgaudit.log = 'read, WRITE'",<not logged>
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log_relation = on;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_relation = on,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log = 'read, WRITE';
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,"ALTER ROLE regress_user1 SET pgaudit.log = 'read, WRITE'",<not logged>
+\connect - regress_user1
 --
 -- Not logged
 CREATE TABLE ACCOUNT_ROLE_MAP
@@ -516,10 +516,10 @@ CREATE TABLE ACCOUNT_ROLE_MAP
 	role_id INT
 );
 --
--- ROLE class not set, so auditor grants not logged
+-- ROLE class not set, so regress_auditor grants not logged
 GRANT SELECT
    ON TABLE public.account_role_map
-   TO auditor;
+   TO regress_auditor;
 --
 -- Object logged because of:
 -- select (password) on account
@@ -592,9 +592,9 @@ NOTICE:  AUDIT: SESSION,4,1,READ,SELECT,TABLE,public.account,"SELECT *
   FROM account
  WHERE password = 'HASH2'
    FOR UPDATE",<not logged>
- id | name  | password | description 
-----+-------+----------+-------------
-  1 | user1 | HASH2    | yada, yada
+ id |     name      | password | description 
+----+---------------+----------+-------------
+  1 | regress_user1 | HASH2    | yada, yada
 (1 row)
 
 --
@@ -623,20 +623,20 @@ NOTICE:  AUDIT: SESSION,6,1,WRITE,UPDATE,TABLE,public.account,"UPDATE account
 --
 -- Change configuration of user 1 so that full statements are not logged
 \connect - :current_user
-ALTER ROLE user1 RESET pgaudit.log_relation;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log_relation,<not logged>
-ALTER ROLE user1 RESET pgaudit.log;
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log,<not logged>
-ALTER ROLE user1 SET pgaudit.log_statement = OFF;
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_statement = OFF,<not logged>
-\connect - user1
+ALTER ROLE regress_user1 RESET pgaudit.log_relation;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 RESET pgaudit.log_relation,<not logged>
+ALTER ROLE regress_user1 RESET pgaudit.log;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 RESET pgaudit.log,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF;
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF,<not logged>
+\connect - regress_user1
 --
 -- Logged but without full statement
 SELECT * FROM account;
 NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,<not logged>,<not logged>
- id | name  | password | description 
-----+-------+----------+-------------
-  1 | user1 | HASH2    | yada, yada
+ id |     name      | password | description 
+----+---------------+----------+-------------
+  1 | regress_user1 | HASH2    | yada, yada
 (1 row)
 
 --
@@ -671,7 +671,7 @@ NOTICE:  AUDIT: SESSION,7,1,DDL,CREATE SCHEMA,SCHEMA,test,CREATE SCHEMA test,<no
 -- Copy account to stdout
 COPY account TO stdout;
 NOTICE:  AUDIT: SESSION,8,1,READ,SELECT,TABLE,public.account,COPY account TO stdout,<none>
-1	user1	HASH2	yada, yada
+1	regress_user1	HASH2	yada, yada
 --
 -- Create a table from a query
 CREATE TABLE test.account_copy AS
@@ -703,9 +703,9 @@ SELECT *
   FROM account
  WHERE id = $1",1
 NOTICE:  AUDIT: SESSION,12,2,MISC,EXECUTE,,,EXECUTE pgclassstmt (1),<none>
- id | name  | password | description 
-----+-------+----------+-------------
-  1 | user1 | HASH2    | yada, yada
+ id |     name      | password | description 
+----+---------------+----------+-------------
+  1 | regress_user1 | HASH2    | yada, yada
 (1 row)
 
 DEALLOCATE pgclassstmt;
@@ -1042,19 +1042,19 @@ NOTICE:  AUDIT: SESSION,52,1,DDL,DROP DATABASE,,,DROP DATABASE contrib_regressio
 -- Test role as a substmt
 SET pgaudit.log = 'ROLE';
 CREATE TABLE t ();
-CREATE ROLE alice;
-NOTICE:  AUDIT: SESSION,53,1,ROLE,CREATE ROLE,,,CREATE ROLE alice,<none>
+CREATE ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,53,1,ROLE,CREATE ROLE,,,CREATE ROLE regress_alice,<none>
 CREATE SCHEMA foo2
 	GRANT SELECT
 	   ON public.t
-	   TO alice;
+	   TO regress_alice;
 NOTICE:  AUDIT: SESSION,54,1,ROLE,GRANT,TABLE,,"CREATE SCHEMA foo2
 	GRANT SELECT
 	   ON public.t
-	   TO alice",<none>
+	   TO regress_alice",<none>
 drop table public.t;
-drop role alice;
-NOTICE:  AUDIT: SESSION,55,1,ROLE,DROP ROLE,,,drop role alice,<none>
+drop role regress_alice;
+NOTICE:  AUDIT: SESSION,55,1,ROLE,DROP ROLE,,,drop role regress_alice,<none>
 --
 -- Test for non-empty stack error
 CREATE OR REPLACE FUNCTION get_test_id(_ret REFCURSOR) RETURNS REFCURSOR
@@ -1137,14 +1137,14 @@ NOTICE:  AUDIT: SESSION,59,3,READ,SELECT,TABLE,public.hoge,select * from hoge,<n
 --
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 create table bar
 (
 	col int
 );
 grant delete
    on bar
-   to auditor;
+   to regress_auditor;
 insert into bar (col)
 		 values (1);
 NOTICE:  AUDIT: SESSION,60,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
@@ -1166,14 +1166,14 @@ drop table bar;
 --
 -- Grant roles to each other
 SET pgaudit.log = 'role';
-GRANT user1 TO user2;
-NOTICE:  AUDIT: SESSION,64,1,ROLE,GRANT ROLE,,,GRANT user1 TO user2,<none>
-REVOKE user1 FROM user2;
-NOTICE:  AUDIT: SESSION,65,1,ROLE,REVOKE ROLE,,,REVOKE user1 FROM user2,<none>
+GRANT regress_user1 TO regress_user2;
+NOTICE:  AUDIT: SESSION,64,1,ROLE,GRANT ROLE,,,GRANT regress_user1 TO regress_user2,<none>
+REVOKE regress_user1 FROM regress_user2;
+NOTICE:  AUDIT: SESSION,65,1,ROLE,REVOKE ROLE,,,REVOKE regress_user1 FROM regress_user2,<none>
 --
 -- Test that FK references do not log but triggers still do
 SET pgaudit.log = 'READ,WRITE';
-SET pgaudit.role TO 'auditor';
+SET pgaudit.role TO 'regress_auditor';
 CREATE TABLE aaa
 (
 	ID int primary key
@@ -1194,10 +1194,10 @@ CREATE TRIGGER bbb_insert_trg
 	FOR EACH ROW EXECUTE PROCEDURE bbb_insert();
 GRANT SELECT, UPDATE
    ON aaa
-   TO auditor;
+   TO regress_auditor;
 GRANT UPDATE
    ON bbb
-   TO auditor;
+   TO regress_auditor;
 INSERT INTO aaa VALUES (generate_series(1,100));
 NOTICE:  AUDIT: SESSION,66,1,WRITE,INSERT,TABLE,public.aaa,"INSERT INTO aaa VALUES (generate_series(1,100))",<none>
 SET pgaudit.log_parameter TO OFF;
@@ -1231,9 +1231,9 @@ SET pgaudit.log_relation = ON;
 NOTICE:  AUDIT: SESSION,72,1,MISC,SET,,,SET pgaudit.log_relation = ON,<none>
 SET pgaudit.log_parameter = ON;
 NOTICE:  AUDIT: SESSION,73,1,MISC,SET,,,SET pgaudit.log_parameter = ON,<none>
-CREATE ROLE alice;
-SET ROLE alice;
-NOTICE:  AUDIT: SESSION,74,1,MISC,SET,,,SET ROLE alice,<none>
+CREATE ROLE regress_alice;
+SET ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,74,1,MISC,SET,,,SET ROLE regress_alice,<none>
 CREATE TABLE t (a int, b text);
 SET search_path TO test, public;
 NOTICE:  AUDIT: SESSION,75,1,MISC,SET,,,"SET search_path TO test, public",<none>
@@ -1246,8 +1246,8 @@ NOTICE:  AUDIT: SESSION,77,1,MISC,RESET,,,RESET ROLE,<none>
 -- Test MISC_SET
 SET pgaudit.log = 'MISC_SET';
 NOTICE:  AUDIT: SESSION,78,1,MISC,SET,,,SET pgaudit.log = 'MISC_SET',<none>
-SET ROLE alice;
-NOTICE:  AUDIT: SESSION,79,1,MISC,SET,,,SET ROLE alice,<none>
+SET ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,79,1,MISC,SET,,,SET ROLE regress_alice,<none>
 SET search_path TO public;
 NOTICE:  AUDIT: SESSION,80,1,MISC,SET,,,SET search_path TO public,<none>
 INSERT INTO t VALUES (2, 'misc_set');
@@ -1267,8 +1267,8 @@ RESET ROLE;
 NOTICE:  AUDIT: SESSION,85,1,MISC,RESET,,,RESET ROLE,<none>
 DROP TABLE public.t;
 NOTICE:  AUDIT: SESSION,86,1,DDL,DROP TABLE,,,DROP TABLE public.t,<none>
-DROP ROLE alice;
-NOTICE:  AUDIT: SESSION,87,1,ROLE,DROP ROLE,,,DROP ROLE alice,<none>
+DROP ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,87,1,ROLE,DROP ROLE,,,DROP ROLE regress_alice,<none>
 --
 -- Test PARTITIONED table
 CREATE TABLE h(x int ,y int) PARTITION BY HASH(x);
@@ -1638,22 +1638,22 @@ NOTICE:  AUDIT: SESSION,36,1,DDL,DROP FUNCTION,,,DROP FUNCTION test2_change(int)
 --
 -- Only object logging will be done
 SET pgaudit.log = 'none';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 --
 -- Select is session logged
 SELECT *
   FROM account;
 NOTICE:  AUDIT: OBJECT,37,1,READ,SELECT,TABLE,public.account,"SELECT *
   FROM account",<none>,1
- id | name  | password | description 
-----+-------+----------+-------------
-  1 | user1 | HASH2    | yada, yada
+ id |     name      | password | description 
+----+---------------+----------+-------------
+  1 | regress_user1 | HASH2    | yada, yada
 (1 row)
 
 --
 -- Insert is not logged
 INSERT INTO account (id, name, password, description)
-			 VALUES (1, 'user2', 'HASH3', 'blah, blah2');
+			 VALUES (1, 'regress_user2', 'HASH3', 'blah, blah2');
 INSERT INTO account (id, name, password, description)
 			 VALUES (1, 'user3', 'HASH4', 'blah, blah3');
 --
@@ -1661,10 +1661,10 @@ INSERT INTO account (id, name, password, description)
 SELECT id,
 	   name
   FROM account;
- id | name  
-----+-------
-  1 | user1
-  1 | user2
+ id |     name      
+----+---------------
+  1 | regress_user1
+  1 | regress_user2
   1 | user3
 (3 rows)
 
@@ -1804,8 +1804,8 @@ NOTICE:  test
 --
 -- Copy account to stdout
 COPY account TO stdout;
-1	user1	HASH4	yada, yada3
-1	user2	HASH4	yada, yada3
+1	regress_user1	HASH4	yada, yada3
+1	regress_user2	HASH4	yada, yada3
 1	user3	HASH4	yada, yada3
 NOTICE:  AUDIT: SESSION,51,1,READ,COPY,,,COPY account TO stdout,<none>,0
 --
@@ -2248,15 +2248,15 @@ NOTICE:  AUDIT: SESSION,110,1,DDL,DROP DATABASE,,,DROP DATABASE contrib_regressi
 -- Test role as a substmt
 SET pgaudit.log = 'role';
 CREATE TABLE t ();
-CREATE ROLE alice;
-NOTICE:  AUDIT: SESSION,111,1,ROLE,CREATE ROLE,,,CREATE ROLE alice,<none>,0
+CREATE ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,111,1,ROLE,CREATE ROLE,,,CREATE ROLE regress_alice,<none>,0
 CREATE SCHEMA foo3
 	GRANT SELECT
 	   ON public.t
-	   TO alice;
+	   TO regress_alice;
 drop table public.t;
-drop role alice;
-NOTICE:  AUDIT: SESSION,112,1,ROLE,DROP ROLE,,,drop role alice,<none>,0
+drop role regress_alice;
+NOTICE:  AUDIT: SESSION,112,1,ROLE,DROP ROLE,,,drop role regress_alice,<none>,0
 --
 -- Test for non-empty stack error
 CREATE OR REPLACE FUNCTION get_test_id(_ret REFCURSOR) RETURNS REFCURSOR
@@ -2330,14 +2330,14 @@ NOTICE:  AUDIT: SESSION,115,2,READ,SELECT,,,SELECT test1(),<none>,1
 --
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 create table bar
 (
 	col int
 );
 grant delete
    on bar
-   to auditor;
+   to regress_auditor;
 insert into bar (col)
 		 values (1);
 NOTICE:  AUDIT: SESSION,116,1,WRITE,INSERT,TABLE,public.bar,"insert into bar (col)
@@ -2359,7 +2359,7 @@ drop table bar;
 --
 -- Test that FK references do not log but triggers still do
 SET pgaudit.log = 'read, write';
-SET pgaudit.role TO 'auditor';
+SET pgaudit.role TO 'regress_auditor';
 CREATE TABLE aaa
 (
 	ID int primary key
@@ -2380,10 +2380,10 @@ CREATE TRIGGER bbb_insert_trg1
 	FOR EACH ROW EXECUTE PROCEDURE bbb_insert1();
 GRANT SELECT, UPDATE
    ON aaa
-   TO auditor;
+   TO regress_auditor;
 GRANT UPDATE
    ON bbb
-   TO auditor;
+   TO regress_auditor;
 INSERT INTO aaa VALUES (generate_series(1,100));
 NOTICE:  AUDIT: SESSION,120,1,WRITE,INSERT,TABLE,public.aaa,"INSERT INTO aaa VALUES (generate_series(1,100))",<none>,100
 SET pgaudit.log_parameter TO OFF;
@@ -2408,9 +2408,9 @@ SET pgaudit.log_relation = on;
 NOTICE:  AUDIT: SESSION,124,1,MISC,SET,,,SET pgaudit.log_relation = on,<none>,0
 SET pgaudit.log_parameter = on;
 NOTICE:  AUDIT: SESSION,125,1,MISC,SET,,,SET pgaudit.log_parameter = on,<none>,0
-CREATE ROLE alice;
-SET ROLE alice;
-NOTICE:  AUDIT: SESSION,126,1,MISC,SET,,,SET ROLE alice,<none>,0
+CREATE ROLE regress_alice;
+SET ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,126,1,MISC,SET,,,SET ROLE regress_alice,<none>,0
 CREATE TABLE t (a int, b text);
 SET search_path TO test, public;
 NOTICE:  AUDIT: SESSION,127,1,MISC,SET,,,"SET search_path TO test, public",<none>,0
@@ -2423,8 +2423,8 @@ NOTICE:  AUDIT: SESSION,129,1,MISC,RESET,,,RESET ROLE,<none>,0
 -- Test MISC_SET
 SET pgaudit.log = 'MISC_SET';
 NOTICE:  AUDIT: SESSION,130,1,MISC,SET,,,SET pgaudit.log = 'MISC_SET',<none>,0
-SET ROLE alice;
-NOTICE:  AUDIT: SESSION,131,1,MISC,SET,,,SET ROLE alice,<none>,0
+SET ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,131,1,MISC,SET,,,SET ROLE regress_alice,<none>,0
 SET search_path TO public;
 NOTICE:  AUDIT: SESSION,132,1,MISC,SET,,,SET search_path TO public,<none>,0
 INSERT INTO t VALUES (2, 'misc_set');
@@ -2444,8 +2444,8 @@ RESET ROLE;
 NOTICE:  AUDIT: SESSION,137,1,MISC,RESET,,,RESET ROLE,<none>,0
 DROP TABLE public.t;
 NOTICE:  AUDIT: SESSION,138,1,DDL,DROP TABLE,,,DROP TABLE public.t,<none>,0
-DROP ROLE alice;
-NOTICE:  AUDIT: SESSION,139,1,ROLE,DROP ROLE,,,DROP ROLE alice,<none>,0
+DROP ROLE regress_alice;
+NOTICE:  AUDIT: SESSION,139,1,ROLE,DROP ROLE,,,DROP ROLE regress_alice,<none>,0
 --
 -- Test PARTITIONED table
 CREATE TABLE h(x int ,y int) PARTITION BY HASH(x);
@@ -2479,24 +2479,24 @@ NOTICE:  AUDIT: SESSION,148,1,DDL,DROP TABLE,,,DROP TABLE h,<none>,0
 --
 -- Change configuration of user 1 so that full statements are not logged
 \connect - :current_user
-ALTER ROLE user1 RESET pgaudit.log_relation;
-NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log_relation,<not logged>
-ALTER ROLE user1 RESET pgaudit.log;
-NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 RESET pgaudit.log,<not logged>
-ALTER ROLE user1 SET pgaudit.log_statement = OFF;
-NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_statement = OFF,<not logged>
-ALTER ROLE user1 SET pgaudit.log_rows = on;
-NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE user1 SET pgaudit.log_rows = on,<not logged>
-\connect - user1
+ALTER ROLE regress_user1 RESET pgaudit.log_relation;
+NOTICE:  AUDIT: SESSION,1,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 RESET pgaudit.log_relation,<not logged>
+ALTER ROLE regress_user1 RESET pgaudit.log;
+NOTICE:  AUDIT: SESSION,2,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 RESET pgaudit.log,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF;
+NOTICE:  AUDIT: SESSION,3,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF,<not logged>
+ALTER ROLE regress_user1 SET pgaudit.log_rows = on;
+NOTICE:  AUDIT: SESSION,4,1,ROLE,ALTER ROLE,,,ALTER ROLE regress_user1 SET pgaudit.log_rows = on,<not logged>
+\connect - regress_user1
 --
 -- Logged but without full statement
 SELECT * FROM account;
 NOTICE:  AUDIT: OBJECT,1,1,READ,SELECT,TABLE,public.account,<not logged>,<not logged>,3
- id | name  | password | description 
-----+-------+----------+-------------
-  1 | user1 | HASH4    | yada, yada3
-  1 | user2 | HASH4    | yada, yada3
-  1 | user3 | HASH4    | yada, yada3
+ id |     name      | password | description 
+----+---------------+----------+-------------
+  1 | regress_user1 | HASH4    | yada, yada3
+  1 | regress_user2 | HASH4    | yada, yada3
+  1 | user3         | HASH4    | yada, yada3
 (3 rows)
 
 --
@@ -2544,12 +2544,12 @@ CREATE EXTENSION postgres_fdw;
 NOTICE:  AUDIT: SESSION,6,1,DDL,CREATE EXTENSION,,,CREATE EXTENSION postgres_fdw,<not logged>
 CREATE SERVER fdw_server FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'foo', dbname 'foodb', port '5432');
 NOTICE:  AUDIT: SESSION,7,1,DDL,CREATE SERVER,,,"CREATE SERVER fdw_server FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'foo', dbname 'foodb', port '5432')",<not logged>
-CREATE USER MAPPING FOR user1 SERVER fdw_server OPTIONS (user 'user1', password 'secret');
-NOTICE:  AUDIT: SESSION,8,1,ROLE,CREATE USER MAPPING,,,"CREATE USER MAPPING FOR user1 SERVER fdw_server OPTIONS (user 'user1', password <REDACTED>",<not logged>
-ALTER USER MAPPING FOR user1 SERVER fdw_server OPTIONS (SET /* comment */ password 'secret2');
-NOTICE:  AUDIT: SESSION,9,1,ROLE,ALTER USER MAPPING,,,ALTER USER MAPPING FOR user1 SERVER fdw_server OPTIONS (SET /* comment */ password <REDACTED>,<not logged>
-DROP USER MAPPING FOR user1 SERVER fdw_server;
-NOTICE:  AUDIT: SESSION,10,1,DDL,DROP USER MAPPING,,,DROP USER MAPPING FOR user1 SERVER fdw_server,<not logged>
+CREATE USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (user 'regress_user1', password 'secret');
+NOTICE:  AUDIT: SESSION,8,1,ROLE,CREATE USER MAPPING,,,"CREATE USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (user 'regress_user1', password <REDACTED>",<not logged>
+ALTER USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (SET /* comment */ password 'secret2');
+NOTICE:  AUDIT: SESSION,9,1,ROLE,ALTER USER MAPPING,,,ALTER USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (SET /* comment */ password <REDACTED>,<not logged>
+DROP USER MAPPING FOR regress_user1 SERVER fdw_server;
+NOTICE:  AUDIT: SESSION,10,1,DDL,DROP USER MAPPING,,,DROP USER MAPPING FOR regress_user1 SERVER fdw_server,<not logged>
 DROP SERVER fdw_server;
 NOTICE:  AUDIT: SESSION,11,1,DDL,DROP SERVER,,,DROP SERVER fdw_server,<not logged>
 DROP EXTENSION postgres_fdw;
@@ -2585,7 +2585,7 @@ DROP SCHEMA foo;
 DROP TABLE hoge;
 DROP TABLE account;
 DROP TABLE account_role_map;
-DROP USER user2;
-DROP USER user1;
-DROP ROLE auditor;
+DROP USER regress_user2;
+DROP USER regress_user1;
+DROP ROLE regress_auditor;
 RESET client_min_messages;

--- a/sql/pgaudit.sql
+++ b/sql/pgaudit.sql
@@ -49,23 +49,23 @@ ALTER ROLE :current_user SET pgaudit.log_client = ON;
 
 --
 -- Create auditor role
-CREATE ROLE auditor;
+CREATE ROLE regress_auditor;
 
 --
 -- Create first test user
-CREATE USER user1 password 'password';
-ALTER ROLE user1 SET pgaudit.log = 'ddl, ROLE';
-ALTER ROLE user1 SET pgaudit.log_level = 'notice';
+CREATE USER regress_user1 password 'password';
+ALTER ROLE regress_user1 SET pgaudit.log = 'ddl, ROLE';
+ALTER ROLE regress_user1 SET pgaudit.log_level = 'notice';
 
-ALTER ROLE user1 PassWord 'password2' NOLOGIN;
-ALTER USER user1 encrypted /* random comment */PASSWORD
+ALTER ROLE regress_user1 PassWord 'password2' NOLOGIN;
+ALTER USER regress_user1 encrypted /* random comment */PASSWORD
 	/* random comment */
     'md565cb1da342495ea6bb0418a6e5718c38' LOGIN;
-ALTER ROLE user1 SET pgaudit.log_client = ON;
+ALTER ROLE regress_user1 SET pgaudit.log_client = ON;
 
 --
 -- Create, select, drop (select will not be audited)
-\connect - user1
+\connect - regress_user1
 
 CREATE TABLE public.test
 (
@@ -81,13 +81,13 @@ DROP TABLE test;
 -- Create second test user
 \connect - :current_user
 
-CREATE ROLE user2 LOGIN password 'password';
-ALTER ROLE user2 SET pgaudit.log = 'Read, writE';
-ALTER ROLE user2 SET pgaudit.log_catalog = OFF;
-ALTER ROLE user2 SET pgaudit.log_client = ON;
-ALTER ROLE user2 SET pgaudit.log_level = 'warning';
-ALTER ROLE user2 SET pgaudit.role = auditor;
-ALTER ROLE user2 SET pgaudit.log_statement_once = ON;
+CREATE ROLE regress_user2 LOGIN password 'password';
+ALTER ROLE regress_user2 SET pgaudit.log = 'Read, writE';
+ALTER ROLE regress_user2 SET pgaudit.log_catalog = OFF;
+ALTER ROLE regress_user2 SET pgaudit.log_client = ON;
+ALTER ROLE regress_user2 SET pgaudit.log_level = 'warning';
+ALTER ROLE regress_user2 SET pgaudit.role = regress_auditor;
+ALTER ROLE regress_user2 SET pgaudit.log_statement_once = ON;
 
 --
 -- Setup role-based tests
@@ -98,11 +98,11 @@ CREATE TABLE test2
 
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test2
-   TO user2, user1;
+   TO regress_user2, regress_user1;
 
 GRANT SELECT, UPDATE
    ON TABLE public.test2
-   TO auditor;
+   TO regress_auditor;
 
 CREATE TABLE test3
 (
@@ -111,11 +111,11 @@ CREATE TABLE test3
 
 GRANT SELECT, INSERT, UPDATE, DELETE
    ON test3
-   TO user2;
+   TO regress_user2;
 
 GRANT INSERT
    ON TABLE public.test3
-   TO auditor;
+   TO regress_auditor;
 
 CREATE FUNCTION test2_insert() RETURNS TRIGGER AS $$
 BEGIN
@@ -125,7 +125,7 @@ BEGIN
 
 	RETURN new;
 END $$ LANGUAGE plpgsql security definer;
-ALTER FUNCTION test2_insert() OWNER TO user1;
+ALTER FUNCTION test2_insert() OWNER TO regress_user1;
 
 CREATE TRIGGER test2_insert_trg
 	AFTER INSERT ON test2
@@ -137,7 +137,7 @@ BEGIN
 	   SET id = id + 1
 	 WHERE id = change_id;
 END $$ LANGUAGE plpgsql security definer;
-ALTER FUNCTION test2_change(int) OWNER TO user2;
+ALTER FUNCTION test2_change(int) OWNER TO regress_user2;
 
 CREATE VIEW vw_test3 AS
 SELECT *
@@ -145,13 +145,13 @@ SELECT *
 
 GRANT SELECT
    ON vw_test3
-   TO user2;
+   TO regress_user2;
 
 GRANT SELECT
    ON vw_test3
-   TO auditor;
+   TO regress_auditor;
 
-\connect - user2
+\connect - regress_user2
 
 --
 -- Role-based tests
@@ -237,9 +237,9 @@ SELECT *
 --
 -- Change permissions of user 2 so that only object logging will be done
 \connect - :current_user
-ALTER ROLE user2 SET pgaudit.log = 'NONE';
+ALTER ROLE regress_user2 SET pgaudit.log = 'NONE';
 
-\connect - user2
+\connect - regress_user2
 
 --
 -- Create test4 and add permissions
@@ -251,15 +251,15 @@ CREATE TABLE test4
 
 GRANT SELECT (name)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 
 GRANT UPDATE (id)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 
 GRANT insert (name)
    ON TABLE public.test4
-   TO auditor;
+   TO regress_auditor;
 
 --
 -- Not object logged
@@ -304,10 +304,10 @@ update public.test4 set name = 'foo' where name = 'bar';
 -- Confirm that "long" parameter values will not be logged if pgaudit.log_parameter_max_size
 -- is set.
 \connect - :current_user
-ALTER ROLE user2 SET pgaudit.log_parameter_max_size = 50;
-ALTER ROLE user2 SET pgaudit.log_parameter = 'on';
+ALTER ROLE regress_user2 SET pgaudit.log_parameter_max_size = 50;
+ALTER ROLE regress_user2 SET pgaudit.log_parameter = 'on';
 
-\connect - user2
+\connect - regress_user2
 PREPARE testinsert(int, text) AS
     INSERT INTO test4 VALUES($1, $2);
 
@@ -316,9 +316,9 @@ EXECUTE testinsert(1, '*******************************************************')
 DEALLOCATE testinsert;
 
 \connect - :current_user
-ALTER ROLE user2 RESET pgaudit.log_parameter_max_size;
+ALTER ROLE regress_user2 RESET pgaudit.log_parameter_max_size;
 
-\connect - user2
+\connect - regress_user2
 PREPARE testinsert(int, text) AS
     INSERT INTO test4 VALUES($1, $2);
 
@@ -327,7 +327,7 @@ EXECUTE testinsert(2, '*******************************************************')
 DEALLOCATE testinsert;
 
 \connect - :current_user
-ALTER ROLE user2 RESET pgaudit.log_parameter;
+ALTER ROLE regress_user2 RESET pgaudit.log_parameter;
 
 --
 -- Change permissions of user 1 so that session logging will be done
@@ -342,8 +342,8 @@ DROP TABLE test4;
 DROP FUNCTION test2_insert();
 DROP FUNCTION test2_change(int);
 
-ALTER ROLE user1 SET pgaudit.log = 'DDL, READ';
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log = 'DDL, READ';
+\connect - regress_user1
 
 --
 -- Create table is session logged
@@ -363,21 +363,21 @@ SELECT *
 --
 -- Insert is not logged
 INSERT INTO account (id, name, password, description)
-			 VALUES (1, 'user1', 'HASH1', 'blah, blah');
+			 VALUES (1, 'regress_user1', 'HASH1', 'blah, blah');
 
 --
 -- Change permissions of user 1 so that only object logging will be done
 \connect - :current_user
-ALTER ROLE user1 SET pgaudit.log = 'none';
-ALTER ROLE user1 SET pgaudit.role = 'auditor';
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log = 'none';
+ALTER ROLE regress_user1 SET pgaudit.role = 'regress_auditor';
+\connect - regress_user1
 
 --
--- ROLE class not set, so auditor grants not logged
+-- ROLE class not set, so regress_auditor grants not logged
 GRANT SELECT (password),
 	  UPDATE (name, password)
    ON TABLE public.account
-   TO auditor;
+   TO regress_auditor;
 
 --
 -- Not object logged
@@ -405,9 +405,9 @@ UPDATE account
 --
 -- Change permissions of user 1 so that session relation logging will be done
 \connect - :current_user
-ALTER ROLE user1 SET pgaudit.log_relation = on;
-ALTER ROLE user1 SET pgaudit.log = 'read, WRITE';
-\connect - user1
+ALTER ROLE regress_user1 SET pgaudit.log_relation = on;
+ALTER ROLE regress_user1 SET pgaudit.log = 'read, WRITE';
+\connect - regress_user1
 
 --
 -- Not logged
@@ -418,10 +418,10 @@ CREATE TABLE ACCOUNT_ROLE_MAP
 );
 
 --
--- ROLE class not set, so auditor grants not logged
+-- ROLE class not set, so regress_auditor grants not logged
 GRANT SELECT
    ON TABLE public.account_role_map
-   TO auditor;
+   TO regress_auditor;
 
 --
 -- Object logged because of:
@@ -474,10 +474,10 @@ UPDATE account
 --
 -- Change configuration of user 1 so that full statements are not logged
 \connect - :current_user
-ALTER ROLE user1 RESET pgaudit.log_relation;
-ALTER ROLE user1 RESET pgaudit.log;
-ALTER ROLE user1 SET pgaudit.log_statement = OFF;
-\connect - user1
+ALTER ROLE regress_user1 RESET pgaudit.log_relation;
+ALTER ROLE regress_user1 RESET pgaudit.log;
+ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF;
+\connect - regress_user1
 
 --
 -- Logged but without full statement
@@ -516,7 +516,7 @@ SELECT *
 --
 -- Copy from stdin to account copy
 COPY test.account_copy from stdin;
-1	user1	HASH2	yada, yada
+1	regress_user1	HASH2	yada, yada
 \.
 
 --
@@ -709,15 +709,15 @@ DROP DATABASE contrib_regression_pgaudit2;
 SET pgaudit.log = 'ROLE';
 
 CREATE TABLE t ();
-CREATE ROLE alice;
+CREATE ROLE regress_alice;
 
 CREATE SCHEMA foo2
 	GRANT SELECT
 	   ON public.t
-	   TO alice;
+	   TO regress_alice;
 
 drop table public.t;
-drop role alice;
+drop role regress_alice;
 
 --
 -- Test for non-empty stack error
@@ -763,7 +763,7 @@ SELECT test();
 --
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 
 create table bar
 (
@@ -772,7 +772,7 @@ create table bar
 
 grant delete
    on bar
-   to auditor;
+   to regress_auditor;
 
 insert into bar (col)
 		 values (1);
@@ -788,13 +788,13 @@ drop table bar;
 --
 -- Grant roles to each other
 SET pgaudit.log = 'role';
-GRANT user1 TO user2;
-REVOKE user1 FROM user2;
+GRANT regress_user1 TO regress_user2;
+REVOKE regress_user1 FROM regress_user2;
 
 --
 -- Test that FK references do not log but triggers still do
 SET pgaudit.log = 'READ,WRITE';
-SET pgaudit.role TO 'auditor';
+SET pgaudit.role TO 'regress_auditor';
 
 CREATE TABLE aaa
 (
@@ -820,11 +820,11 @@ CREATE TRIGGER bbb_insert_trg
 
 GRANT SELECT, UPDATE
    ON aaa
-   TO auditor;
+   TO regress_auditor;
 
 GRANT UPDATE
    ON bbb
-   TO auditor;
+   TO regress_auditor;
 
 INSERT INTO aaa VALUES (generate_series(1,100));
 
@@ -852,9 +852,9 @@ SET pgaudit.log_client = ON;
 SET pgaudit.log_relation = ON;
 SET pgaudit.log_parameter = ON;
 
-CREATE ROLE alice;
+CREATE ROLE regress_alice;
 
-SET ROLE alice;
+SET ROLE regress_alice;
 CREATE TABLE t (a int, b text);
 SET search_path TO test, public;
 
@@ -867,7 +867,7 @@ RESET ROLE;
 -- Test MISC_SET
 SET pgaudit.log = 'MISC_SET';
 
-SET ROLE alice;
+SET ROLE regress_alice;
 SET search_path TO public;
 
 INSERT INTO t VALUES (2, 'misc_set');
@@ -887,7 +887,7 @@ VACUUM t;
 
 RESET ROLE;
 DROP TABLE public.t;
-DROP ROLE alice;
+DROP ROLE regress_alice;
 
 --
 -- Test PARTITIONED table
@@ -1050,7 +1050,7 @@ DROP FUNCTION test2_change(int);
 --
 -- Only object logging will be done
 SET pgaudit.log = 'none';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 
 --
 -- Select is session logged
@@ -1060,7 +1060,7 @@ SELECT *
 --
 -- Insert is not logged
 INSERT INTO account (id, name, password, description)
-			 VALUES (1, 'user2', 'HASH3', 'blah, blah2');
+			 VALUES (1, 'regress_user2', 'HASH3', 'blah, blah2');
 INSERT INTO account (id, name, password, description)
 			 VALUES (1, 'user3', 'HASH4', 'blah, blah3');
 
@@ -1163,7 +1163,7 @@ SELECT *
 --
 -- Copy from stdin to account copy
 COPY test.account_copy from stdin;
-1	user1	HASH4	yada, yada4
+1	regress_user1	HASH4	yada, yada4
 \.
 
 --
@@ -1389,15 +1389,15 @@ DROP DATABASE contrib_regression_pgaudit2;
 SET pgaudit.log = 'role';
 
 CREATE TABLE t ();
-CREATE ROLE alice;
+CREATE ROLE regress_alice;
 
 CREATE SCHEMA foo3
 	GRANT SELECT
 	   ON public.t
-	   TO alice;
+	   TO regress_alice;
 
 drop table public.t;
-drop role alice;
+drop role regress_alice;
 
 --
 -- Test for non-empty stack error
@@ -1438,7 +1438,7 @@ SELECT test1();
 --
 -- Delete all rows then delete 1 row
 SET pgaudit.log = 'write';
-SET pgaudit.role = 'auditor';
+SET pgaudit.role = 'regress_auditor';
 
 create table bar
 (
@@ -1447,7 +1447,7 @@ create table bar
 
 grant delete
    on bar
-   to auditor;
+   to regress_auditor;
 
 insert into bar (col)
 		 values (1);
@@ -1463,7 +1463,7 @@ drop table bar;
 --
 -- Test that FK references do not log but triggers still do
 SET pgaudit.log = 'read, write';
-SET pgaudit.role TO 'auditor';
+SET pgaudit.role TO 'regress_auditor';
 
 CREATE TABLE aaa
 (
@@ -1489,11 +1489,11 @@ CREATE TRIGGER bbb_insert_trg1
 
 GRANT SELECT, UPDATE
    ON aaa
-   TO auditor;
+   TO regress_auditor;
 
 GRANT UPDATE
    ON bbb
-   TO auditor;
+   TO regress_auditor;
 
 INSERT INTO aaa VALUES (generate_series(1,100));
 
@@ -1511,9 +1511,9 @@ SET pgaudit.log_client = on;
 SET pgaudit.log_relation = on;
 SET pgaudit.log_parameter = on;
 
-CREATE ROLE alice;
+CREATE ROLE regress_alice;
 
-SET ROLE alice;
+SET ROLE regress_alice;
 CREATE TABLE t (a int, b text);
 SET search_path TO test, public;
 
@@ -1526,7 +1526,7 @@ RESET ROLE;
 -- Test MISC_SET
 SET pgaudit.log = 'MISC_SET';
 
-SET ROLE alice;
+SET ROLE regress_alice;
 SET search_path TO public;
 
 INSERT INTO t VALUES (2, 'misc_set');
@@ -1545,7 +1545,7 @@ VACUUM t;
 
 RESET ROLE;
 DROP TABLE public.t;
-DROP ROLE alice;
+DROP ROLE regress_alice;
 
 --
 -- Test PARTITIONED table
@@ -1562,11 +1562,11 @@ DROP TABLE h;
 --
 -- Change configuration of user 1 so that full statements are not logged
 \connect - :current_user
-ALTER ROLE user1 RESET pgaudit.log_relation;
-ALTER ROLE user1 RESET pgaudit.log;
-ALTER ROLE user1 SET pgaudit.log_statement = OFF;
-ALTER ROLE user1 SET pgaudit.log_rows = on;
-\connect - user1
+ALTER ROLE regress_user1 RESET pgaudit.log_relation;
+ALTER ROLE regress_user1 RESET pgaudit.log;
+ALTER ROLE regress_user1 SET pgaudit.log_statement = OFF;
+ALTER ROLE regress_user1 SET pgaudit.log_rows = on;
+\connect - regress_user1
 
 --
 -- Logged but without full statement
@@ -1623,10 +1623,10 @@ SET pgaudit.log_level = 'notice';
 CREATE EXTENSION postgres_fdw;
 CREATE SERVER fdw_server FOREIGN DATA WRAPPER postgres_fdw OPTIONS (host 'foo', dbname 'foodb', port '5432');
 
-CREATE USER MAPPING FOR user1 SERVER fdw_server OPTIONS (user 'user1', password 'secret');
-ALTER USER MAPPING FOR user1 SERVER fdw_server OPTIONS (SET /* comment */ password 'secret2');
+CREATE USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (user 'regress_user1', password 'secret');
+ALTER USER MAPPING FOR regress_user1 SERVER fdw_server OPTIONS (SET /* comment */ password 'secret2');
 
-DROP USER MAPPING FOR user1 SERVER fdw_server;
+DROP USER MAPPING FOR regress_user1 SERVER fdw_server;
 DROP SERVER fdw_server;
 DROP EXTENSION postgres_fdw;
 
@@ -1664,8 +1664,8 @@ DROP SCHEMA foo;
 DROP TABLE hoge;
 DROP TABLE account;
 DROP TABLE account_role_map;
-DROP USER user2;
-DROP USER user1;
-DROP ROLE auditor;
+DROP USER regress_user2;
+DROP USER regress_user1;
+DROP ROLE regress_auditor;
 
 RESET client_min_messages;


### PR DESCRIPTION
Compiling PostgreSQL with -DENFORCE_REGRESSION_TEST_NAME_RESTRICTIONS causes the regression test suite of pgaudit to fail because the roles created do not comply with the upstream rule for role names, where these should be suffixed with "regress_".

The tests fail when creating such non-compliant roles with warnings like this one:
WARNING:  roles created by regression test cases should have names starting with "regress_"

The regression test coverage does not change with the roles renamed, and the expected output is updated accordingly.