### PR TITLE
Fix search_path for trigger functions.

### DIFF
--- a/pgaudit--17.0.sql
+++ b/pgaudit--17.0.sql
@@ -4,7 +4,7 @@
 CREATE FUNCTION pgaudit_ddl_command_end()
 	RETURNS event_trigger
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog, pg_temp'
+	SET search_path = pg_catalog, pg_temp
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgaudit_ddl_command_end';
 
@@ -15,7 +15,7 @@ CREATE EVENT TRIGGER pgaudit_ddl_command_end
 CREATE FUNCTION pgaudit_sql_drop()
 	RETURNS event_trigger
 	SECURITY DEFINER
-	SET search_path = 'pg_catalog, pg_temp'
+	SET search_path = pg_catalog, pg_temp
 	LANGUAGE C
 	AS 'MODULE_PATHNAME', 'pgaudit_sql_drop';
 


### PR DESCRIPTION
When quoting the value for the search_path in create function the whole string is treated as a single schema instead of multiple individual schemas resulting in the effective search_path being pg_temp, pg_catalog, "pg_catalog, pg_temp".

Fixes #221
