### PR TITLE
Error when required hooks are skipped.

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -290,6 +290,18 @@ static int64 stackTotal = 0;
 static bool statementLogged = false;
 
 /*
+ * Check that the stack is not empty for callbacks that add data to an audit
+ * event that was started by the ProcessUtility or ExecutorCheckPerms hooks.
+ *
+ * We are unable to continue in this case without losing an audit record. If
+ * the caller is purposefully breaking the hook sequence when they will need
+ * to disable auditing for the duration of the operation.
+ */
+ #define STACK_NOT_EMPTY() \
+    if (auditEventStack == NULL) \
+        elog(ERROR, "pgaudit stack is empty");
+
+/*
  * Stack functions
  *
  * Audit events can go down to multiple levels so a stack is maintained to keep
@@ -1398,7 +1410,7 @@ pgaudit_ExecutorStart_hook(QueryDesc *queryDesc, int eflags)
 
     if (!internalStatement)
     {
-        /* Push the audit even onto the stack */
+        /* Push the audit event onto the stack */
         stackItem = stack_push();
 
         /* Initialize command using queryDesc->operation */
@@ -1509,7 +1521,10 @@ pgaudit_ExecutorCheckPerms_hook(List *rangeTabls, List *permInfos, bool abort)
             }
         }
         else
+        {
+            STACK_NOT_EMPTY();
             log_select_dml(auditOid, rangeTabls, permInfos);
+        }
     }
 
     /* Call the next hook function */
@@ -1541,7 +1556,10 @@ pgaudit_ExecutorRun_hook(QueryDesc *queryDesc, ScanDirection direction, uint64 c
 
         /* Accumulate the number of rows processed */
         if (stackItem != NULL)
+        {
+            STACK_NOT_EMPTY();
             stackItem->auditEvent.rows += queryDesc->estate->es_processed;
+        }
     }
 }
 
@@ -1561,6 +1579,8 @@ pgaudit_ExecutorEnd_hook(QueryDesc *queryDesc)
 
         if (stackItem != NULL && stackItem->auditEvent.rangeTabls != NULL)
         {
+            STACK_NOT_EMPTY();
+
             /* Reset auditEventStack to use in log_select_dml() */
             auditEventStackFull = auditEventStack;
             auditEventStack = stackItem;


### PR DESCRIPTION
If the initial hooks (ProcessUtility or ExecutorCheckPerms) that setup an audit event are skipped then later hooks will be left without an event to update and log, which leads to a segfault.

In this case an audit event will be lost and it seems incorrect to just do that silently. The current behavior of segfaulting is not OK so instead throw an error in these cases.

If the user wants to proceed then they will need to disable auditing, assuming they have permission to do so.