### PR TITLE
Use strpbrk() instead of strstr()s when applicable.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-EXTRA_INSTALL += contrib/pg_stat_statements contrib/postgres_fdw
+EXTRA_INSTALL += contrib/pg_stat_statements

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-EXTRA_INSTALL += contrib/pg_stat_statements
+EXTRA_INSTALL += contrib/pg_stat_statements contrib/postgres_fdw

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -525,9 +525,8 @@ append_valid_csv(StringInfoData *buffer, const char *appendStr)
     if (appendStr == NULL)
         return;
 
-    /* Only format for CSV if appendStr contains: ", comma, \n, \r */
-    if (strstr(appendStr, ",") || strstr(appendStr, "\"") ||
-        strstr(appendStr, "\n") || strstr(appendStr, "\r"))
+    /* Only format for CSV if appendStr contains: comma, ", \n, \r */
+    if (strpbrk(appendStr, ",\"\n\r"))
     {
         appendStringInfoCharMacro(buffer, '"');
 


### PR DESCRIPTION
There is a place in pgaudit.c that checks if a string contains characters c1...cN, by calling strstr() for every character in this sequence. This piece of code can be simplified by replacing these calls with just a single call to strpbrk(). In addition, this patch reorders the list of characters in a corresponding comment to make the order consistent with the actual code.