### PR TITLE
Fix `make check` by pre-installing postgres_fdw.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk
 endif
 
-EXTRA_INSTALL += contrib/pg_stat_statements
+EXTRA_INSTALL += contrib/pg_stat_statements contrib/postgres_fdw


### PR DESCRIPTION
Tests performed by `make check` use several extensions, including contrib/postgres_fdw, but this extension isn't mentioned in Makefile, causing errors like

ERROR:  extension "postgres_fdw" is not available
ERROR:  foreign-data wrapper "postgres_fdw" does not exist

and so on. This patch fixes this by adding contrib/postgres_fdw to a relevant variable in the makefile.