### PR TITLE
Fix parameter type when calling VARSIZE_ANY_EXHDR.

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -835,7 +835,7 @@ log_audit_event(AuditEventStackItem *stackItem)
 
                 if (auditLogParameterMaxSize > 0 &&
                     typeIsVarLena &&
-                    VARSIZE_ANY_EXHDR(prm->value) > auditLogParameterMaxSize)
+                    VARSIZE_ANY_EXHDR(DatumGetPointer(prm->value)) > auditLogParameterMaxSize)
                 {
                     append_valid_csv(&paramStrResult,
                                      "<long param suppressed>");


### PR DESCRIPTION
Recently VARSIZE_ANY_EXHDR and other similar macros were converted to inline functions in the master Postgres branch, and these functions don't accept Datum data type anymore.This patch fixes a compilation error caused by this change.