### PR TITLE
Fix compiler warnings

### DIFF
--- a/pgaudit.c
+++ b/pgaudit.c
@@ -363,7 +363,7 @@ stack_free(void *stackFree)
  * store it.
  */
 static AuditEventStackItem *
-stack_push()
+stack_push(void)
 {
     MemoryContext contextAudit;
     MemoryContext contextOld;
@@ -667,7 +667,8 @@ log_audit_event(AuditEventStackItem *stackItem)
                             pfree(commandStr);
                     }
 
-                /* Fall through */
+                /* fallthrough */
+                pg_fallthrough;
 
                 /* Classify role statements */
                 case T_GrantStmt:
@@ -835,7 +836,7 @@ log_audit_event(AuditEventStackItem *stackItem)
 
                 if (auditLogParameterMaxSize > 0 &&
                     typeIsVarLena &&
-                    VARSIZE_ANY_EXHDR(prm->value) > auditLogParameterMaxSize)
+                    VARSIZE_ANY_EXHDR(&prm->value) > auditLogParameterMaxSize)
                 {
                     append_valid_csv(&paramStrResult,
                                      "<long param suppressed>");


### PR DESCRIPTION
pgaudit emitting warnings when compiled against latest postgresql head

```
de/postgresql/internal -D_GNU_SOURCE     -c -o pgaudit.o pgaudit.c -MMD -MP -MF .deps/pgaudit.Po
pgaudit.c:366:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
  366 | stack_push()
      | ^~~~~~~~~~
pgaudit.c: In function ‘stack_push’:
pgaudit.c:366:1: warning: old-style function definition [-Wold-style-definition]
pgaudit.c: In function ‘log_audit_event’:
pgaudit.c:838:42: warning: passing argument 1 of ‘VARSIZE_ANY_EXHDR’ makes pointer from integer without a cast [-Wint-conversion]
  838 |                     VARSIZE_ANY_EXHDR(prm->value) > auditLogParameterMaxSize)
      |                                       ~~~^~~~~~~
      |                                          |
      |                                          Datum {aka long unsigned int}
In file included from /home/imran/Desktop/work/pg/installs/pg19-dev/include/postgresql/server/access/tupmacs.h:20,
                 from /home/imran/Desktop/work/pg/installs/pg19-dev/include/postgresql/server/access/htup_details.h:20,
                 from pgaudit.c:13:
/home/imran/Desktop/work/pg/installs/pg19-dev/include/postgresql/server/varatt.h:472:31: note: expected ‘const void *’ but argument is of type ‘Datum’ {aka ‘long unsigned int’}
  472 | VARSIZE_ANY_EXHDR(const void *PTR)
      |                   ~~~~~~~~~~~~^~~
pgaudit.c:625:24: warning: this statement may fall through [-Wimplicit-fallthrough=]
  625 |                     if (stackItem->auditEvent.commandText != NULL)
      |                        ^
pgaudit.c:673:17: note: here
  673 |                 case T_GrantStmt:
      |                 ^~~~

```